### PR TITLE
Align Makefile - Bundle Creation Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,13 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+##@ Bundle Creation Addition
+## Some addition to bundle creation in the bundle
+
+.PHONY: bundle-reset-date
+bundle-reset-date: ## Reset bundle's createdAt
+	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to
@@ -259,6 +266,7 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(MAKE) bundle-reset-date
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,12 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 ##@ Bundle Creation Addition
 ## Some addition to bundle creation in the bundle
 
+.PHONY: bundle-update
+bundle-update: ## Update containerImage, and createdAt fields in the bundle's CSV
+	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
+	$(OPERATOR_SDK) bundle validate ./bundle
+
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt
 	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
@@ -270,7 +276,7 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
-bundle-build: ## Build the bundle image.
+bundle-build: bundle-update ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: ""
-    createdAt: "2023-01-30T09:57:47Z"
+    createdAt: ""
     description: Fence Agents Remediation Operator for remeidating nodes using upstream
       fence-agents.
     operators.operatorframework.io/builder: operator-sdk-v1.26.0


### PR DESCRIPTION
In the process of moving FAR to Medik8s organization we align the Makefile - **fifth** PR.

Small changes to bundle creation (similarly to https://github.com/medik8s/node-healthcheck-operator/pull/141, https://github.com/medik8s/self-node-remediation/pull/72, and https://github.com/medik8s/node-maintenance-operator/pull/68 PRs).

- Reset bundle's createdAt field ( [operator-sdk to v1.26.0](https://github.com/operator-framework/operator-sdk/releases/tag/v1.26.0) adds the [createdAt field](https://github.com/operator-framework/operator-sdk/commit/fe1e18c1b96c2b47d51c1cd33c0dc564eb66ebfd#diff-5f7bc62652b60bcf694b6fb39b2114b24bfa6559ac7f31969c12ee6034cec3a9) after running `make bundle`).
- Add new target for setting the CSV under bundle directory, before building the bundle container (_containerImage_, and _createdAt_ fields).

