### PR TITLE
Fix url-install-tool Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ define url-install-tool
 	set -e ;\
 	rm -rf $(2) ;\
 	mkdir -p $(dir $(1)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(1) $(3) ;\
 	chmod +x $(1) ;\
 	}


### PR DESCRIPTION
Missing OS and ARCH variables for downloading and installing opm and operator-sdk.