### PR TITLE
Missing operator-sdk target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 ## Some addition to bundle creation in the bundle
 
 .PHONY: bundle-update
-bundle-update: ## Update containerImage, and createdAt fields in the bundle's CSV
+bundle-update: operator-sdk ## Update containerImage, and createdAt fields in the bundle's CSV, then validate the bundle directory
 	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle


### PR DESCRIPTION
It is required for the `bundle-update`, otherwise `bundle-build` will fail in Github CI.
Failure:

> make container-build
> .
> .
> .
> Successfully built 395db3c40f30
> Successfully tagged quay.io/medik8s/fence-agents-remediation-operator:latest
> sed -r -i "s|containerImage: .*|containerImage: quay.io/medik8s/fence-agents-remediation-operator:latest|;" ./bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
> sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ./bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
> /home/runner/work/fence-agents-remediation/fence-agents-remediation/bin/operator-sdk/v1.26.0/operator-sdk bundle validate ./bundle
> bash: line 1: /home/runner/work/fence-agents-remediation/fence-agents-remediation/bin/operator-sdk/v1.26.0/operator-sdk: No such file or directory