### PR TITLE
FAR E2E Test - Check Node Reboot by Boot Time and Patch CredentialsRequest for AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,11 +401,16 @@ container-push: docker-push bundle-push catalog-build catalog-push ## Push conta
 .PHONY: container-build-and-push-community
 container-build-and-push-community: container-build-community container-push ## Build three images, update CSV for community, and push all the images to Quay (docker, bundle, and catalog).
 
+export OCP_AWS_CREDENTIALS ="config/ocp_aws/fence_aws_credentials_request.yaml"
+.PHONY: ocp-aws-credentials
+ocp-aws-credentials: ## Add CredentialsRequest for OCP on AWS
+	$(KUBECTL) create -f ${OCP_AWS_CREDENTIALS}
+
 .PHONY: test-e2e
 # -r: If set, ginkgo finds and runs test suites under the current directory recursively.
 # --keep-going:  If set, failures from earlier test suites do not prevent later test suites from running.
 # --require-suite: If set, Ginkgo fails if there are ginkgo tests in a directory but no invocation of RunSpecs.
 # --vv: If set, emits with maximal verbosity - includes skipped and pending tests.
-test-e2e: ginkgo ## Run end to end (E2E) tests
+test-e2e: ocp-aws-credentials ginkgo ## Run end to end (E2E) tests
 	@test -n "${KUBECONFIG}" -o -r ${HOME}/.kube/config || (echo "Failed to find kubeconfig in ~/.kube/config or no KUBECONFIG set"; exit 1)
 	$(GINKGO) -r --keep-going --require-suite --vv  ./test/e2e -coverprofile cover.out

--- a/config/ocp_aws/fence_aws_credentials_request.yaml
+++ b/config/ocp_aws/fence_aws_credentials_request.yaml
@@ -1,0 +1,45 @@
+# similar to https://github.com/openshift/machine-api-operator/blob/master/install/0000_30_machine-api-operator_00_credentials-request.yaml#L1-L6
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-aws-cloud-fencing
+  namespace: openshift-cloud-credential-operator
+spec:
+  serviceAccountNames:
+  - fence-agents-remediation-controller-manager
+  secretRef:
+    name: aws-cloud-fencing-credentials-secret
+    namespace: openshift-operators
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+# https://github.com/openshift/cloud-credential-operator/blob/master/pkg/apis/cloudcredential/v1/types_aws.go
+    statementEntries:
+    - action:
+      - ec2:StartInstances
+      - ec2:StopInstances
+      - ec2:DescribeImages
+      - ec2:DescribeInstances
+      - ec2:RunInstances
+      - ec2:TerminateInstances
+      - iam:PassRole
+      - iam:CreateServiceLinkedRole
+      effect: Allow
+      resource: "*"
+    - action:
+      - kms:Decrypt
+      - kms:Encrypt
+      - kms:GenerateDataKey
+      - kms:GenerateDataKeyWithoutPlainText
+      - kms:DescribeKey
+      effect: Allow
+      resource: '*'
+    - action:
+      - kms:RevokeGrant
+      - kms:CreateGrant
+      - kms:ListGrants
+      effect: Allow
+      resource: '*'
+      policyCondition:
+        "Bool":
+          "kms:GrantIsForAWSResource": true

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -114,8 +114,10 @@ var _ = Describe("FAR Controller", func() {
 		//Scenarios
 		BeforeEach(func() {
 			fenceAgentsPod = buildFarPod()
-			// DeferCleanUp and Create fenceAgentsPod
+			// Create, Update status (for GetFenceAgentsRemediationPod), and DeferCleanUp the fenceAgentsPod
 			Expect(k8sClient.Create(context.Background(), fenceAgentsPod)).To(Succeed())
+			fenceAgentsPod.Status.Phase = corev1.PodRunning
+			Expect(k8sClient.Status().Update(context.Background(), fenceAgentsPod)).To(Succeed())
 			DeferCleanup(k8sClient.Delete, context.Background(), fenceAgentsPod)
 		})
 		JustBeforeEach(func() {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.11.2
 )
 
@@ -72,7 +73,6 @@ require (
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const WorkerLabelName = "node-role.kubernetes.io/worker"
+
 // getNodeWithName returns a node with a name nodeName, or an error if it can't be found
 func getNodeWithName(r client.Reader, nodeName string) (*corev1.Node, error) {
 	node := &corev1.Node{}

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -21,17 +21,20 @@ import (
 )
 
 const (
-	fenceAgentDummyName  = "echo"
-	fenceAgentAWS        = "fence_aws"
-	fenceAgentIPMI       = "fence_ipmilan"
-	fenceAgentAction     = "status"
-	nodeIndex            = 0
-	succeesStatusMessage = "ON"
-	containerName        = "manager"
+	fenceAgentAWS            = "fence_aws"
+	fenceAgentIPMI           = "fence_ipmilan"
+	fenceAgentAction         = "reboot"
+	nodeIdentifierPrefixAWS  = "--plug"
+	nodeIdentifierPrefixIPMI = "--ipport"
+	nodeIndex                = 3
+	succeesRebootMessage     = "\"Success: Rebooted"
+	containerName            = "manager"
 
 	// eventually parameters
-	timeoutLogs  = 1 * time.Minute
-	pollInterval = 10 * time.Second
+	//TODO: try to minimize timeout
+	timeoutLogs   = 6 * time.Minute
+	timeoutReboot = 10 * time.Minute
+	pollInterval  = 10 * time.Second
 )
 
 var _ = Describe("FAR E2e", func() {
@@ -49,15 +52,22 @@ var _ = Describe("FAR E2e", func() {
 		fmt.Printf("\ncluster name: %s and PlatformType: %s \n", string(clusterPlatform.Name), string(clusterPlatform.Status.PlatformStatus.Type))
 	})
 
-	Context("fence agent", func() {
+	Context("fence agent - fence_aws or fence_ipmilan", func() {
+		var (
+			nodeBootTimeBefore   time.Time
+			errBoot              error
+			testNodeName         string
+			nodeIdentifierPrefix string
+			testNodeID           string
+		)
 		BeforeEach(func() {
 			nodes := &corev1.NodeList{}
 			Expect(k8sClient.List(context.Background(), nodes, &client.ListOptions{})).ToNot(HaveOccurred())
 			if len(nodes.Items) <= 1 {
 				Fail("there is one or less available nodes in the cluster")
 			}
-			//TODO: Randomize the node selection
-			// run FA on the first node - a master node
+			//TODO: Randomize the node selection & verify valid index
+			// run FA on the fourth node - a worker node
 			nodeObj := nodes.Items[nodeIndex]
 			testNodeName := nodeObj.Name
 			log.Info("Testing Node", "Node name", testNodeName)
@@ -65,9 +75,11 @@ var _ = Describe("FAR E2e", func() {
 			switch clusterPlatform.Status.PlatformStatus.Type {
 			case configv1.AWSPlatformType:
 				fenceAgent = fenceAgentAWS
+				nodeIdentifierPrefix = nodeIdentifierPrefixAWS
 				By("running fence_aws")
 			case configv1.BareMetalPlatformType:
 				fenceAgent = fenceAgentIPMI
+				nodeIdentifierPrefix = nodeIdentifierPrefixIPMI
 				By("running fence_ipmilan")
 			default:
 				Skip("FAR haven't been tested on this kind of cluster (non AWS or BareMetal)")
@@ -81,12 +93,17 @@ var _ = Describe("FAR E2e", func() {
 			if err != nil {
 				Fail("can't get node information")
 			}
+			nodeName := v1alpha1.NodeName(testNodeName)
+			parameterName := v1alpha1.ParameterName(nodeIdentifierPrefix)
+			testNodeID = testNodeParam[parameterName][nodeName]
+			log.Info("Testing Node", "Node name", testNodeName, "Node ID", testNodeID)
+
+			// save the node's boot time prior to the fence agent call
+			nodeBootTimeBefore, errBoot = getNodeBootTime(testNodeName)
+			Expect(errBoot).ToNot(HaveOccurred(), "failed to get boot time of the node")
 
 			far = createFAR(testNodeName, fenceAgent, testShareParam, testNodeParam)
-		})
-
-		AfterEach(func() {
-			deleteFAR(far)
+			DeferCleanup(deleteFAR, far)
 		})
 
 		When("running FAR to reboot node ", func() {
@@ -96,7 +113,10 @@ var _ = Describe("FAR E2e", func() {
 				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(far), testFarCR)).To(Succeed(), "failed to get FAR CR")
 
 				By("checking the command has been executed successfully")
-				checkFarLogs(succeesStatusMessage)
+				checkFarLogs(succeesRebootMessage)
+
+				By("checking the node's boot time after running the FA")
+				wasNodeRebooted(testNodeName, nodeBootTimeBefore)
 			})
 		})
 	})
@@ -197,7 +217,7 @@ func buildNodeParameters(clusterPlatformType configv1.PlatformType) (map[v1alpha
 			fmt.Printf("can't get nodes' information - AWS instance ID\n")
 			return nil, err
 		}
-		nodeIdentifier = v1alpha1.ParameterName("--plug")
+		nodeIdentifier = v1alpha1.ParameterName(nodeIdentifierPrefixAWS)
 
 	} else if clusterPlatformType == configv1.BareMetalPlatformType {
 		nodeListParam, err = e2eUtils.GetBMHNodeInfoList(machineClient)
@@ -205,10 +225,19 @@ func buildNodeParameters(clusterPlatformType configv1.PlatformType) (map[v1alpha
 			fmt.Printf("can't get nodes' information - ports\n")
 			return nil, err
 		}
-		nodeIdentifier = v1alpha1.ParameterName("--ipport")
+		nodeIdentifier = v1alpha1.ParameterName(nodeIdentifierPrefixIPMI)
 	}
 	testNodeParam = map[v1alpha1.ParameterName]map[v1alpha1.NodeName]string{nodeIdentifier: nodeListParam}
 	return testNodeParam, nil
+}
+
+// getNodeBootTime returns the bootime of node nodeName if possible, otherwise it returns an error
+func getNodeBootTime(nodeName string) (time.Time, error) {
+	bootTime, err := e2eUtils.GetBootTime(clientSet, nodeName, testNsName, log)
+	if bootTime != nil && err == nil {
+		return *bootTime, nil
+	}
+	return time.Time{}, err
 }
 
 // checkFarLogs gets the FAR pod and checks whether it's logs have logString
@@ -232,4 +261,21 @@ func checkFarLogs(logString string) {
 		}
 		return logs
 	}, timeoutLogs, pollInterval).Should(ContainSubstring(logString))
+}
+
+// wasNodeRebooted waits until there is a newer boot time than before, a reboot occurred, otherwise it falls with an error
+func wasNodeRebooted(nodeName string, nodeBootTimeBefore time.Time) {
+	log.Info("boot time", "node", nodeName, "old", nodeBootTimeBefore)
+	var nodeBootTimeAfter time.Time
+	Eventually(func() (time.Time, error) {
+		var errBootAfter error
+		nodeBootTimeAfter, errBootAfter = getNodeBootTime(nodeName)
+		if errBootAfter != nil {
+			log.Error(errBootAfter, "Can't get boot time of the node")
+		}
+		return nodeBootTimeAfter, errBootAfter
+	}, timeoutReboot, pollInterval).Should(
+		BeTemporally(">", nodeBootTimeBefore), "Timeout for node reboot has passed, even though FAR CR has been created")
+
+	log.Info("successful reboot", "node", nodeName, "offset between last boot", nodeBootTimeAfter.Sub(nodeBootTimeBefore), "new boot time", nodeBootTimeAfter)
 }

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -33,8 +33,9 @@ const (
 
 	//TODO: try to minimize timeout
 	// eventually parameters
-	timeoutLogs   = 6 * time.Minute
-	timeoutReboot = 10 * time.Minute // fencing with fence_aws should be completed within 6 minutes
+	timeoutGetPod = 1 * time.Minute
+	timeoutLogs   = 3 * time.Minute
+	timeoutReboot = 6 * time.Minute // fencing with fence_aws should be completed within 6 minutes
 	pollInterval  = 10 * time.Second
 )
 
@@ -259,7 +260,7 @@ func getFarPod() *corev1.Pod {
 			return nil
 		}
 		return pod
-	}, timeoutLogs, pollInterval).ShouldNot(BeNil(), "can't find the pod after timeout")
+	}, timeoutGetPod, pollInterval).ShouldNot(BeNil(), "can't find the pod after timeout")
 	return pod
 }
 

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -31,8 +31,8 @@ const (
 	succeesRebootMessage     = "\"Success: Rebooted"
 	containerName            = "manager"
 
-	// eventually parameters
 	//TODO: try to minimize timeout
+	// eventually parameters
 	timeoutLogs   = 6 * time.Minute
 	timeoutReboot = 10 * time.Minute // fencing with fence_aws should be completed within 6 minutes
 	pollInterval  = 10 * time.Second
@@ -154,7 +154,6 @@ func deleteFAR(far *v1alpha1.FenceAgentsRemediation) {
 func buildSharedParameters(clusterPlatform *configv1.Infrastructure, action string) (map[v1alpha1.ParameterName]string, error) {
 	const (
 		//AWS
-		// secretDefaultAWS    = "aws-cloud-credentials"
 		secretAWSName      = "aws-cloud-fencing-credentials-secret"
 		secretAWSNamespace = "openshift-operators"
 		secretKeyAWS       = "aws_access_key_id"
@@ -172,7 +171,7 @@ func buildSharedParameters(clusterPlatform *configv1.Infrastructure, action stri
 	// oc get Infrastructure.config.openshift.io/cluster -o jsonpath='{.status.platformStatus.type}'
 	clusterPlatformType := clusterPlatform.Status.PlatformStatus.Type
 	if clusterPlatformType == configv1.AWSPlatformType {
-		accessKey, secretKey, err := e2eUtils.GetCredentials(clientSet, secretAWSName, secretAWSNamespace, secretKeyAWS, secretValAWS)
+		accessKey, secretKey, err := e2eUtils.GetSecretData(clientSet, secretAWSName, secretAWSNamespace, secretKeyAWS, secretValAWS)
 		if err != nil {
 			fmt.Printf("can't get AWS credentials\n")
 			return nil, err
@@ -193,7 +192,7 @@ func buildSharedParameters(clusterPlatform *configv1.Infrastructure, action stri
 		// TODO : get ip from GetCredientals
 		// oc get bmh -n openshift-machine-api ostest-master-0 -o jsonpath='{.spec.bmc.address}'
 		// then parse ip
-		username, password, err := e2eUtils.GetCredentials(clientSet, secretBMHName, secretBMHNamespace, secretKeyBM, secretValBM)
+		username, password, err := e2eUtils.GetSecretData(clientSet, secretBMHName, secretBMHNamespace, secretKeyBM, secretValBM)
 		if err != nil {
 			fmt.Printf("can't get BMH credentials\n")
 			return nil, err

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -15,9 +15,11 @@ import (
 	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
 )
 
+// See OCP API for Machine in https://docs.openshift.com/container-platform/latest/rest_api/machine_apis/machine-machine-openshift-io-v1beta1.html
+
 const (
-	machinesNamespace   = "openshift-machine-api"
 	clusterPlatformName = "cluster"
+	machinesNamespace   = "openshift-machine-api"
 )
 
 // GetClusterInfo fetch the cluster's infrastructure object to identify it's type
@@ -34,11 +36,11 @@ func GetClusterInfo(config configclient.Interface) (*configv1.Infrastructure, er
 }
 
 // GetCredentials searches for AWS or BMH secret, and then returns it decoded
-func GetCredentials(clientSet *kubernetes.Clientset, secretName, secretKey, secretVal string) (string, string, error) {
+func GetCredentials(clientSet *kubernetes.Clientset, secretName, secretNamespace, secretKey, secretVal string) (string, string, error) {
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_access_key_id}' | base64 -d
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_secret_access_key}' | base64 -d
 
-	secret, err := clientSet.CoreV1().Secrets(machinesNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	secret, err := clientSet.CoreV1().Secrets(secretNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", err
 	}

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -35,7 +35,8 @@ func GetClusterInfo(config configclient.Interface) (*configv1.Infrastructure, er
 	return clusterInfra, nil
 }
 
-// GetSecretData searches for the platform's secret, and then returns it's decoded two data values
+// GetSecretData searches for the platform's secret, and then returns it's decoded two data values.
+// E.g. on AWS it would be the Access Key and it's ID, but on BMH with fence_impilan it would be useranme and password
 func GetSecretData(clientSet *kubernetes.Clientset, secretName, secretNamespace, secretData1, secretData2 string) (string, string, error) {
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_access_key_id}' | base64 -d
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_secret_access_key}' | base64 -d

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
 )
 
+// Inspired from https://github.com/hybrid-cloud-patterns/patterns-operator/blob/main/controllers/pattern_controller.go#L293-L313
 // See OCP API for Machine in https://docs.openshift.com/container-platform/latest/rest_api/machine_apis/machine-machine-openshift-io-v1beta1.html
 
 const (
@@ -24,7 +25,6 @@ const (
 
 // GetClusterInfo fetch the cluster's infrastructure object to identify it's type
 func GetClusterInfo(config configclient.Interface) (*configv1.Infrastructure, error) {
-	// Copy paste from https://github.com/hybrid-cloud-patterns/patterns-operator/blob/main/controllers/pattern_controller.go#L293-L313
 	// oc get Infrastructure.config.openshift.io/cluster -o jsonpath='{.metadata.name}'
 	// oc get Infrastructure.config.openshift.io/cluster -o jsonpath='{.spec.platformSpec.type}'
 
@@ -35,8 +35,8 @@ func GetClusterInfo(config configclient.Interface) (*configv1.Infrastructure, er
 	return clusterInfra, nil
 }
 
-// GetCredentials searches for AWS or BMH secret, and then returns it decoded
-func GetCredentials(clientSet *kubernetes.Clientset, secretName, secretNamespace, secretKey, secretVal string) (string, string, error) {
+// GetSecretData searches for the platform's secret, and then returns it's decoded two data values
+func GetSecretData(clientSet *kubernetes.Clientset, secretName, secretNamespace, secretData1, secretData2 string) (string, string, error) {
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_access_key_id}' | base64 -d
 	// oc get secrets -n openshift-machine-api aws-cloud-credentials -o jsonpath='{.data.aws_secret_access_key}' | base64 -d
 
@@ -44,7 +44,7 @@ func GetCredentials(clientSet *kubernetes.Clientset, secretName, secretNamespace
 	if err != nil {
 		return "", "", err
 	}
-	return string(secret.Data[secretKey]), string(secret.Data[secretVal]), nil
+	return string(secret.Data[secretData1]), string(secret.Data[secretData2]), nil
 }
 
 // GetAWSNodeInfoList returns a list of the node names and their identification, e.g., AWS instance ID

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -1,0 +1,173 @@
+package utils
+
+// Copy paste from https://github.com/medik8s/node-healthcheck-operator/blob/main/e2e/utils/command.go
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
+func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (*time.Time, error) {
+	output, err := RunCommandInCluster(c, nodeName, ns, "microdnf install procps -y >/dev/null 2>&1 && uptime -s", log)
+	if err != nil {
+		return nil, err
+	}
+
+	bootTime, err := time.Parse("2006-01-02 15:04:05", output)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bootTime, nil
+}
+
+// RunCommandInCluster runs a command in a pod in the cluster and returns the output
+func RunCommandInCluster(c *kubernetes.Clientset, nodeName string, ns string, command string, log logr.Logger) (string, error) {
+
+	// create a pod and wait that it's running
+	pod := getPod(nodeName)
+	pod, err := c.CoreV1().Pods(ns).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	err = waitForCondition(c, pod, corev1.PodReady, corev1.ConditionTrue, time.Minute)
+	if err != nil {
+		return "", err
+	}
+
+	log.Info("helper pod is running, going to execute command")
+	cmd := []string{"sh", "-c", command}
+	bytes, err := waitForPodOutput(c, pod, cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}
+
+func waitForPodOutput(c *kubernetes.Clientset, pod *corev1.Pod, command []string) ([]byte, error) {
+	var out []byte
+	if err := wait.PollImmediate(15*time.Second, time.Minute, func() (done bool, err error) {
+		out, err = execCommandOnPod(c, pod, command)
+		if err != nil {
+			return false, err
+		}
+
+		return len(out) != 0, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// execCommandOnPod runs command in the pod and returns buffer output
+func execCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, command []string) ([]byte, error) {
+	var outputBuf bytes.Buffer
+	var errorBuf bytes.Buffer
+
+	req := c.CoreV1().RESTClient().
+		Post().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: pod.Spec.Containers[0].Name,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       true,
+		}, scheme.ParameterCodec)
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: &outputBuf,
+		Stderr: &errorBuf,
+		Tty:    true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to run command %v: error: %v, outputStream %s; errorStream %s", command, err, outputBuf.String(), errorBuf.String())
+	}
+
+	if errorBuf.Len() != 0 {
+		return nil, fmt.Errorf("failed to run command %v: output %s; error %s", command, outputBuf.String(), errorBuf.String())
+	}
+
+	return outputBuf.Bytes(), nil
+}
+
+// waitForCondition waits until the pod will have specified condition type with the expected status
+func waitForCondition(c *kubernetes.Clientset, pod *corev1.Pod, conditionType corev1.PodConditionType, conditionStatus corev1.ConditionStatus, timeout time.Duration) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		updatedPod := &corev1.Pod{}
+		var err error
+		if updatedPod, err = c.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
+			return false, err
+		}
+		for _, c := range updatedPod.Status.Conditions {
+			if c.Type == conditionType && c.Status == conditionStatus {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func getPod(nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "far-test-",
+			Labels: map[string]string{
+				"test": "",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:    nodeName,
+			HostNetwork: true,
+			HostPID:     true,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:  pointer.Int64(0),
+				RunAsGroup: pointer.Int64(0),
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "test",
+					Image: "registry.access.redhat.com/ubi8/ubi-minimal",
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.Bool(true),
+					},
+					Command: []string{"sleep", "2m"},
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -25,18 +25,19 @@ import (
 )
 
 // GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
-func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (*time.Time, error) {
+func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (time.Time, error) {
+	emptyTime := time.Time{}
 	output, err := RunCommandInCluster(c, nodeName, ns, "microdnf install procps -y >/dev/null 2>&1 && uptime -s", log)
 	if err != nil {
-		return nil, err
+		return emptyTime, err
 	}
 
 	bootTime, err := time.Parse("2006-01-02 15:04:05", output)
 	if err != nil {
-		return nil, err
+		return emptyTime, err
 	}
 
-	return &bootTime, nil
+	return bootTime, nil
 }
 
 // RunCommandInCluster runs a command in a pod in the cluster and returns the output


### PR DESCRIPTION
The PR adds the support of running a reboot of OCP node on AWS environment, and the E2E test that checks FAR's code.

Until now the E2E test checked if FAR's CR has been created and if the FA CLI command has been executed correctly by reviewing FAR's pod/container logs (both have been done in #32). Now we check the node's boot time (Kubelet ready condition status transition time) to verify that the FA has been doing a successful reboot.

But for running the **fence_aws** fence agent with a `reboot` action outside of AWS we use the **--skip-race-check** flag, and we patch a CredentialsRequest in OCP to add missing AWS permissions (e.g., _ec2:StartInstances_, and _ec2:StopInstances_).

[ECOPROJECT-1274](https://issues.redhat.com//browse/ECOPROJECT-1274)