### PR TITLE
Correct build container location

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,4 +13,4 @@ LDFLAGS="-s -w "
 LDFLAGS+="-X github.com/medik8s/fence-agents-remediation/version.Version=${VERSION} "
 LDFLAGS+="-X github.com/medik8s/fence-agents-remediation/version.GitCommit=${COMMIT} "
 LDFLAGS+="-X github.com/medik8s/fence-agents-remediation/version.BuildDate=${BUILD_DATE} "
-GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o bin/manager main.go
+GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o manager main.go


### PR DESCRIPTION
Dockerfile was looking to run manager with `/manager` but it was not over there after #24 PR.
The error is `Error: container create failed: time="2023-03-22T10:18:54Z" level=error msg="runc create failed: unable to start container process: exec: \"/manager\": stat /manager: no such file or directory"`