### PR TITLE
Run container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ RUN ./hack/build.sh
 # Add Fence Agents
 RUN dnf install -y fence-agents-all
 
+USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Set USER field in Dockerfile - 
In most systems value 1000 and below is reserved and 65536 is max value for non-root