### PR TITLE
Set minKubeVersion 1.24.0

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -312,6 +312,7 @@ spec:
   - email: medik8s@googlegroups.com
     name: Medik8s Team
   maturity: alpha
+  minKubeVersion: 1.24.0
   provider:
     name: Medik8s
     url: https://github.com/medik8s

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -108,6 +108,7 @@ spec:
   - email: medik8s@googlegroups.com
     name: Medik8s Team
   maturity: alpha
+  minKubeVersion: 1.24.0
   provider:
     name: Medik8s
     url: https://github.com/medik8s


### PR DESCRIPTION
Set minimal Kubernetes version as [v1.24.0](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/) for FAR- Will be used in OperatorHub.

FYI the latest Kubernetes version is[ v1.27.0](https://kubernetes.io/blog/2023/04/11/kubernetes-v1-27-release/) and v1.24.0 is the Kubernetes version which has been used by [OCP 4.11](https://docs.openshift.com/container-platform/4.11/welcome/index.html).