### PR TITLE
Automate GitHub Release Draft

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -6,6 +6,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   push-images:
     name: Build and push images to quay.io/medik8s

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -49,12 +49,13 @@ jobs:
             ## Notable Changes
             
             * TODO
+            
             ## Release Artifacts
             
             ### Images
-            * Operator: quay.io/repository/medik8s/fence-agents-remediation-operator:${{ github.ref_name }}
-            * Bundle: quay.io/repository/medik8s/fence-agents-remediation-operator-bundle:${{ github.ref_name }}
-            * Catalog aka Index: quay.io/repository/medik8s/fence-agents-remediation-operator-catalog:${{ github.ref_name }}
+            * Operator: quay.io/medik8s/fence-agents-remediation-operator:${{ github.ref_name }}
+            * Bundle: quay.io/medik8s/fence-agents-remediation-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/medik8s/fence-agents-remediation-operator-catalog:${{ github.ref_name }}
             
             ### Source code and OLM manifests
             Please find the source code and the OLM manifests in the `Assets` section below.

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -25,9 +25,35 @@ jobs:
 
       - name: Build and push CSV 0.0.1 + latest images for PR merges to main
         if: ${{ github.ref_type != 'tag' }}
-        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push
+        run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push-community
 
       - name: Build and push versioned CSV and images for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export IMAGE_REGISTRY=quay.io/medik8s && export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push-community
+
+      - name: Create release with manifests
+        if: ${{ github.ref_type == 'tag' }}
+        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          body: |
+            # Fence Agents Remediation ${{ github.ref_name }}
+            
+            ## Notable Changes
+            
+            * TODO
+            ## Release Artifacts
+            
+            ### Images
+            * Operator: quay.io/repository/medik8s/fence-agents-remediation-operator:${{ github.ref_name }}
+            * Bundle: quay.io/repository/medik8s/fence-agents-remediation-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/repository/medik8s/fence-agents-remediation-operator-catalog:${{ github.ref_name }}
+            
+            ### Source code and OLM manifests
+            Please find the source code and the OLM manifests in the `Assets` section below.
+          gzip: folders
+          files: >
+            Manifests:bundle/

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -34,4 +34,4 @@ jobs: # jobs to run
       run: make test
 
     - name: Build Images
-      run: make container-build
+      run: make container-build-community

--- a/Makefile
+++ b/Makefile
@@ -384,11 +384,18 @@ verify-unchanged: ## Verify there are no un-committed changes
 .PHONY: container-build 
 container-build: docker-build bundle-build ## Build containers
 
+.PHONY: bundle-build-community
+bundle-build-community: bundle-community ## Run bundle community changes in CSV, and then build the bundle image.
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: container-build-community
+container-build-community: docker-build bundle-build-community ## Build containers for community
+
 .PHONY: container-push 
 container-push: docker-push bundle-push catalog-build catalog-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
 
-.PHONY: container-build-and-push
-container-build-and-push: container-build container-push ## Build and push all the four images to quay (docker, bundle, and catalog).
+.PHONY: container-build-and-push-community
+container-build-and-push-community: container-build-community container-push ## Build three images, update CSV for community, and push all the images to Quay (docker, bundle, and catalog).
 
 .PHONY: test-e2e
 test-e2e: ginkgo ## Run end to end (E2E) tests


### PR DESCRIPTION
Similar to NHC we add automation for the creation of Github Release upon Git tag creation.

[ECOPROJECT-1128](https://issues.redhat.com//browse/ECOPROJECT-1128)