### PR TITLE
Use Downward API for Namespace

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -221,6 +221,11 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: DEPLOYMENT_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/medik8s/fence-agents-remediation-operator:latest
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,11 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+          - name: DEPLOYMENT_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -82,7 +82,6 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 	// TODO: Validate FAR CR name to nodeName. Run isNodeNameValid
 	// Fetch the FAR's pod
 	r.Log.Info("Fetch FAR's pod")
-	// pod, err := r.getFenceAgentsPod()
 	pod, err := utils.GetFenceAgentsRemediationPod(req.Name, r.Client)
 	if err != nil {
 		return emptyResult, err

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -41,7 +41,10 @@ const (
 	fenceAgentIPMI   = "fence_ipmilan"
 )
 
-var faPodLabels = map[string]string{"app": "fence-agents-remediation-operator"}
+var (
+	faPodLabels    = map[string]string{"app": "fence-agents-remediation-operator"}
+	fenceAgentsPod *corev1.Pod
+)
 
 var _ = Describe("FAR Controller", func() {
 	var (
@@ -88,12 +91,11 @@ var _ = Describe("FAR Controller", func() {
 			})
 		})
 	})
-
-	fenceAgentsPod := buildFarPod()
 	Context("Reconcile", func() {
 		//Scenarios
 
 		BeforeEach(func() {
+			fenceAgentsPod = buildFarPod()
 			// Create fenceAgentsPod and FAR
 			Expect(k8sClient.Create(context.Background(), fenceAgentsPod)).NotTo(HaveOccurred())
 			Expect(k8sClient.Create(context.Background(), underTestFAR)).NotTo(HaveOccurred())

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -41,6 +41,8 @@ const (
 	fenceAgentIPMI   = "fence_ipmilan"
 )
 
+var faPodLabels = map[string]string{"app": "fence-agents-remediation-operator"}
+
 var _ = Describe("FAR Controller", func() {
 	var (
 		underTestFAR *v1alpha1.FenceAgentsRemediation
@@ -64,7 +66,6 @@ var _ = Describe("FAR Controller", func() {
 		},
 	}
 	underTestFAR = newFenceAgentsRemediation(validNodeName, fenceAgentIPMI, testShareParam, testNodeParam)
-	fenceAgentsPod := buildFarPod()
 
 	Context("Functionality", func() {
 		Context("buildFenceAgentParams", func() {
@@ -88,6 +89,7 @@ var _ = Describe("FAR Controller", func() {
 		})
 	})
 
+	fenceAgentsPod := buildFarPod()
 	Context("Reconcile", func() {
 		//Scenarios
 

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+// GetDeploymentNamespace returns the Namespace this operator is deployed on.
+func GetDeploymentNamespace() (string, error) {
+	// deployNamespaceEnvVar is the constant for env variable DEPLOYMENT_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	var deployNamespaceEnvVar = "DEPLOYMENT_NAMESPACE"
+
+	ns, found := os.LookupEnv(deployNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
+	}
+	return ns, nil
+}

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -5,16 +5,17 @@ import (
 	"os"
 )
 
-// GetDeploymentNamespace returns the Namespace this operator is deployed on.
-func GetDeploymentNamespace() (string, error) {
-	// deployNamespaceEnvVar is the constant for env variable DEPLOYMENT_NAMESPACE
-	// which specifies the Namespace to watch.
-	// An empty value means the operator is running with cluster scope.
-	var deployNamespaceEnvVar = "DEPLOYMENT_NAMESPACE"
+// deployNamespaceEnv is a constant for env variable DEPLOYMENT_NAMESPACE
+// which specifies the Namespace that the operator's deployment was installed/run.
+// It has been set using Downward API (https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) in manager.yaml
+const deployNamespaceEnv = "DEPLOYMENT_NAMESPACE"
 
-	ns, found := os.LookupEnv(deployNamespaceEnvVar)
+// GetDeploymentNamespace returns the Namespace this operator is deployed/installed on.
+func GetDeploymentNamespace() (string, error) {
+
+	ns, found := os.LookupEnv(deployNamespaceEnv)
 	if !found {
-		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
+		return "", fmt.Errorf("%s must be set", deployNamespaceEnv)
 	}
 	return ns, nil
 }

--- a/pkg/utils/pods.go
+++ b/pkg/utils/pods.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetFenceAgentsRemediationPod fetches the FAR pod based on FAR's label and namespace
+func GetFenceAgentsRemediationPod(nodeName string, r client.Reader) (*corev1.Pod, error) {
+	pods := &corev1.PodList{}
+
+	selector := labels.NewSelector()
+	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"fence-agents-remediation-operator"})
+	selector = selector.Add(*requirement)
+	podNamespace, _ := GetDeploymentNamespace()
+
+	err := r.List(context.Background(), pods, &client.ListOptions{LabelSelector: selector, Namespace: podNamespace})
+	if err != nil {
+		fmt.Printf("failed fetching FAR pod")
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		fmt.Printf("No Fence Agent pods were found")
+		podNotFoundErr := &apiErrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Code:   http.StatusNotFound,
+			Reason: metav1.StatusReasonNotFound,
+		}}
+		return nil, podNotFoundErr
+	}
+
+	return &pods.Items[0], nil
+}


### PR DESCRIPTION
[Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) simplifies the code by getting the pod's namespace without hard code the value. It stores the pod's namespace in environment variable - `DEPLOYMENT_NAMESPACE` as it [was suggested](https://github.com/medik8s/fence-agents-remediation/pull/16#discussion_r1113279956) earlier in #16.

Fix [ECOPROJECT-1234](https://issues.redhat.com//browse/ECOPROJECT-1234)