### PR TITLE
Use Kubernetes Recommended Label for commonLabels

### DIFF
--- a/bundle/manifests/fence-agents-remediation-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/fence-agents-remediation-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
     control-plane: controller-manager
   name: fence-agents-remediation-controller-manager-metrics-service
 spec:
@@ -13,7 +13,7 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/fence-agents-remediation-ext-remediation_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/fence-agents-remediation-ext-remediation_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
     rbac.ext-remediation/aggregate-to-ext-remediation: "true"
   name: fence-agents-remediation-ext-remediation
 rules:

--- a/bundle/manifests/fence-agents-remediation-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/fence-agents-remediation-manager-config_v1_configmap.yaml
@@ -15,5 +15,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
   name: fence-agents-remediation-manager-config

--- a/bundle/manifests/fence-agents-remediation-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/fence-agents-remediation-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
   name: fence-agents-remediation-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -178,14 +178,14 @@ spec:
         serviceAccountName: fence-agents-remediation-controller-manager
       deployments:
       - label:
-          app: fence-agents-remediation-operator
+          app.kubernetes.io/name: fence-agents-remediation-operator
           control-plane: controller-manager
         name: fence-agents-remediation-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
-              app: fence-agents-remediation-operator
+              app.kubernetes.io/name: fence-agents-remediation-operator
               control-plane: controller-manager
           strategy: {}
           template:
@@ -193,7 +193,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                app: fence-agents-remediation-operator
+                app.kubernetes.io/name: fence-agents-remediation-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
+++ b/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
   name: fenceagentsremediations.fence-agents-remediation.medik8s.io
 spec:
   group: fence-agents-remediation.medik8s.io

--- a/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
+++ b/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
-    app: fence-agents-remediation-operator
+    app.kubernetes.io/name: fence-agents-remediation-operator
   name: fenceagentsremediationtemplates.fence-agents-remediation.medik8s.io
 spec:
   group: fence-agents-remediation.medik8s.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -11,8 +11,7 @@ namePrefix: fence-agents-remediation-
 # Labels to add to all resources and selectors.
 #commonLabels:
 commonLabels:
-  app: "fence-agents-remediation-operator"
-
+  app.kubernetes.io/name: fence-agents-remediation-operator
 bases:
 - ../crd
 - ../rbac

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	faPodLabels    = map[string]string{"app": "fence-agents-remediation-operator"}
+	faPodLabels    = map[string]string{"app.kubernetes.io/name": "fence-agents-remediation-operator"}
 	fenceAgentsPod *corev1.Pod
 )
 

--- a/pkg/utils/pods.go
+++ b/pkg/utils/pods.go
@@ -18,7 +18,7 @@ func GetFenceAgentsRemediationPod(r client.Reader) (*corev1.Pod, error) {
 	logger := ctrl.Log.WithName("utils-pods")
 	pods := &corev1.PodList{}
 	selector := labels.NewSelector()
-	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"fence-agents-remediation-operator"})
+	requirement, _ := labels.NewRequirement("app.kubernetes.io/name", selection.Equals, []string{"fence-agents-remediation-operator"})
 	selector = selector.Add(*requirement)
 	var podNamespace string
 	podNamespace, err := GetDeploymentNamespace()


### PR DESCRIPTION
Changing FAR's label from ` app: fence-agents-remediation-operator` to `app.kubernetes.io/name: fence-agents-remediation-operator`, since it is one of [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) for commonLabels.