### PR TITLE
Set Environment Variable for Tests

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -38,6 +39,8 @@ import (
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const defaultNamespace = "default"
 
 var k8sClient client.Client
 var k8sManager manager.Manager
@@ -80,6 +83,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 	mocksExecuter = newMockExecuter()
+
+	os.Setenv("DEPLOYMENT_NAMESPACE", defaultNamespace)
+
 	err = (&FenceAgentsRemediationReconciler{
 		Client:   k8sClient,
 		Log:      k8sManager.GetLogger().WithName("test far reconciler"),

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -34,10 +34,9 @@ import (
 )
 
 const (
-	defaultNamespace = "default"
-	dummyNodeName    = "dummy-node"
-	validNodeName    = "worker-0"
-	fenceAgentIPMI   = "fence_ipmilan"
+	dummyNodeName  = "dummy-node"
+	validNodeName  = "worker-0"
+	fenceAgentIPMI = "fence_ipmilan"
 )
 
 var (

--- a/pkg/utils/pods.go
+++ b/pkg/utils/pods.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -9,26 +10,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetFenceAgentsRemediationPod fetches the FAR pod based on FAR's label and namespace
 func GetFenceAgentsRemediationPod(r client.Reader) (*corev1.Pod, error) {
-	logger := ctrl.Log.WithName("utils-pods")
+	var podNamespace string
 	pods := &corev1.PodList{}
 	selector := labels.NewSelector()
 	requirement, _ := labels.NewRequirement("app", selection.Equals, []string{"fence-agents-remediation-operator"})
 	selector = selector.Add(*requirement)
-	var podNamespace string
 	podNamespace, err := GetDeploymentNamespace()
 	if err != nil {
-		logger.Error(err, "failed fetching FAR namespace")
+		return nil, fmt.Errorf("failed fetching FAR namespace - %w", err)
 	}
 	err = r.List(context.Background(), pods, &client.ListOptions{LabelSelector: selector, Namespace: podNamespace})
 	if err != nil {
-		logger.Error(err, "failed fetching FAR pod")
-		return nil, err
+		return nil, fmt.Errorf("failed fetching FAR pod - %w", err)
 	}
 	if len(pods.Items) == 0 {
 		podNotFoundErr := &apiErrors.StatusError{ErrStatus: metav1.Status{
@@ -36,9 +34,7 @@ func GetFenceAgentsRemediationPod(r client.Reader) (*corev1.Pod, error) {
 			Code:   http.StatusNotFound,
 			Reason: metav1.StatusReasonNotFound,
 		}}
-		logger.Error(podNotFoundErr, "No Fence Agent pods were found")
-		return nil, podNotFoundErr
+		return nil, fmt.Errorf("no Fence Agent pods were found - %w", podNotFoundErr)
 	}
-
 	return &pods.Items[0], nil
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -83,6 +83,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = ctrl.New(config, ctrl.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 
+	os.Setenv("DEPLOYMENT_NAMESPACE", operatorNsName)
+
 	debug()
 })
 


### PR DESCRIPTION
A follow up PR for #42 which add an environment variable DEPLOYMENT_NAMESPACE to the `manager` container, but we need to set in the UT and E2E tests, otherwise they have raised an error (and now they will fail).