### PR TITLE
Reduce Container Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream8 AS builder
 RUN dnf install -y dnf-plugins-core \
-    && dnf config-manager --set-enabled ha
-RUN dnf install -y golang git
-
+    && dnf config-manager --set-enabled ha \
+    && dnf install -y golang git \
+    && dnf clean all -y
 
 # Ensure correct Go version
 ENV GO_VERSION=1.18
-RUN go install golang.org/dl/go${GO_VERSION}@latest
-RUN ~/go/bin/go${GO_VERSION} download
-RUN /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go
-RUN go version
+RUN go install golang.org/dl/go${GO_VERSION}@latest \
+    && ~/go/bin/go${GO_VERSION} download \
+    && /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go \
+    && go version
 
 WORKDIR /
 # Copy the Go Modules manifests
@@ -33,7 +33,8 @@ COPY .git/ .git/
 RUN ./hack/build.sh
 
 # Add Fence Agents and fence-agents-aws packages
-RUN dnf install -y fence-agents-all fence-agents-aws
+RUN dnf install -y fence-agents-all fence-agents-aws \
+    && dnf clean all -y
 
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Drastically minimize container size (~1GB -> ~210MB):

1. Cleaning temporary files after installing external packages -  by using`clean all` (see it also from [container best practices-> Clean temporary files](https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html))
2. Build the container in a [multi-stage](https://docs.docker.com/build/building/multi-stage/) manner to exclude unneeded packages Golang, source files and .git from the final image.