### PR TITLE
Support and Handle Taints

### DIFF
--- a/api/v1alpha1/fenceagentsremediation_types.go
+++ b/api/v1alpha1/fenceagentsremediation_types.go
@@ -30,8 +30,7 @@ const (
 	// FARFinalizer is a finalizer for a FenceAgentsRemediation CR deletion
 	FARFinalizer string = "fence-agents-remediation.medik8s.io/far-finalizer"
 	// Taints
-	Medik8sRemediationTaintKey = "medik8s.io/remediation"
-	FARRemediationTaintValue   = "fence-agents-remediation"
+	FARNoExecuteTaintKey = "medik8s.io/fence-agents-remediation"
 )
 
 // FenceAgentsRemediationSpec defines the desired state of FenceAgentsRemediation

--- a/api/v1alpha1/fenceagentsremediation_types.go
+++ b/api/v1alpha1/fenceagentsremediation_types.go
@@ -27,6 +27,8 @@ type ParameterName string
 type NodeName string
 
 const (
+	// FARFinalizer is a finalizer for a FenceAgentsRemediation CR deletion
+	FARFinalizer string = "fence-agents-remediation.medik8s.io/far-finalizer"
 	// Taints
 	Medik8sRemediationTaintKey = "medik8s.io/remediation"
 	FARRemediationTaintValue   = "fence-agents-remediation"

--- a/api/v1alpha1/fenceagentsremediation_types.go
+++ b/api/v1alpha1/fenceagentsremediation_types.go
@@ -26,6 +26,12 @@ import (
 type ParameterName string
 type NodeName string
 
+const (
+	// Taints
+	Medik8sRemediationTaintKey = "medik8s.io/remediation"
+	FARRemediationTaintValue   = "fence-agents-remediation"
+)
+
 // FenceAgentsRemediationSpec defines the desired state of FenceAgentsRemediation
 type FenceAgentsRemediationSpec struct {
 	// Agent is the name of fence agent that will be used

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -125,8 +125,10 @@ spec:
           resources:
           - nodes
           verbs:
+          - delete
           - get
           - list
+          - patch
           - watch
         - apiGroups:
           - ""

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -128,7 +128,7 @@ spec:
           - delete
           - get
           - list
-          - patch
+          - update
           - watch
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,7 +13,7 @@ rules:
   - delete
   - get
   - list
-  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,8 +10,10 @@ rules:
   resources:
   - nodes
   verbs:
+  - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	//+kubebuilder:scaffold:imports ## https://github.com/kubernetes-sigs/kubebuilder/issues/1487 ?
-	fenceagentsv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = fenceagentsv1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -57,7 +57,7 @@ func (r *FenceAgentsRemediationReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 //+kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;delete;deletecollection
-//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch;delete
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/finalizers,verbs=update

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -114,6 +114,11 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Invalid sharedParameters/nodeParameters from CR", "CR's Name", req.Name)
 		return emptyResult, err
 	}
+	// Add medik8s remediation taint
+	r.Log.Info("Add Medik8s remediation taint", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)
+	if err := utils.AppendTaint(r.Client, far.Name); err != nil {
+		return emptyResult, err
+	}
 	cmd := append([]string{far.Spec.Agent}, faParams...)
 	// The Fence Agent is excutable and the parameters structure are valid, but we don't check their values
 	r.Log.Info("Execute the fence agent", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -29,14 +29,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
 	"github.com/medik8s/fence-agents-remediation/pkg/utils"
 )
 
 const (
-	dummyNodeName  = "dummy-node"
-	validNodeName  = "worker-0"
+	dummyNode      = "dummy-node"
+	node01         = "worker-0"
+	node02         = "worker-1"
 	fenceAgentIPMI = "fence_ipmilan"
 )
 
@@ -68,13 +71,13 @@ var _ = Describe("FAR Controller", func() {
 			"worker-2": "6235",
 		},
 	}
-	underTestFAR = newFenceAgentsRemediation(validNodeName, fenceAgentIPMI, testShareParam, testNodeParam)
+	underTestFAR = getFenceAgentsRemediation(node01, fenceAgentIPMI, testShareParam, testNodeParam)
 
 	Context("Functionality", func() {
 		Context("buildFenceAgentParams", func() {
 			When("FAR CR's name doesn't match a node name", func() {
 				It("should fail", func() {
-					underTestFAR.ObjectMeta.Name = dummyNodeName
+					underTestFAR.ObjectMeta.Name = dummyNode
 					_, err := buildFenceAgentParams(underTestFAR)
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(Equal(errors.New(errorMissingNodeParams)))
@@ -82,7 +85,7 @@ var _ = Describe("FAR Controller", func() {
 			})
 			When("FAR CR's name does match a node name", func() {
 				It("should succeed", func() {
-					underTestFAR.ObjectMeta.Name = validNodeName
+					underTestFAR.ObjectMeta.Name = node01
 					Expect(buildFenceAgentParams(underTestFAR)).Error().NotTo(HaveOccurred())
 				})
 			})
@@ -90,18 +93,18 @@ var _ = Describe("FAR Controller", func() {
 
 		Context("IsNodeNameValid", func() {
 			BeforeEach(func() {
-				node = getNode(validNodeName)
+				node = getNode(node01)
 				DeferCleanup(k8sClient.Delete, context.Background(), node)
 				Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
 			})
 			When("FAR CR's name doesn't match to an existing node name", func() {
 				It("should fail", func() {
-					Expect(utils.IsNodeNameValid(k8sClient, dummyNodeName)).To(BeFalse())
+					Expect(utils.IsNodeNameValid(k8sClient, dummyNode)).To(BeFalse())
 				})
 			})
 			When("FAR's name does match to an existing node name", func() {
 				It("should succeed", func() {
-					Expect(utils.IsNodeNameValid(k8sClient, validNodeName)).To(BeTrue())
+					Expect(utils.IsNodeNameValid(k8sClient, node01)).To(BeTrue())
 				})
 			})
 		})
@@ -110,29 +113,58 @@ var _ = Describe("FAR Controller", func() {
 		//Scenarios
 		BeforeEach(func() {
 			fenceAgentsPod = buildFarPod()
-			node = getNode(validNodeName)
-			// DeferCleanUp and Create node, fenceAgentsPod and FAR CR
-			DeferCleanup(k8sClient.Delete, context.Background(), node)
+			// DeferCleanUp and Create fenceAgentsPod
+			Expect(k8sClient.Create(context.Background(), fenceAgentsPod)).To(Succeed())
 			DeferCleanup(k8sClient.Delete, context.Background(), fenceAgentsPod)
+		})
+		JustBeforeEach(func() {
+			// DeferCleanUp and Create node, and FAR CR
+			DeferCleanup(k8sClient.Delete, context.Background(), node)
 			DeferCleanup(k8sClient.Delete, context.Background(), underTestFAR)
 			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
-			Expect(k8sClient.Create(context.Background(), fenceAgentsPod)).To(Succeed())
 			Expect(k8sClient.Create(context.Background(), underTestFAR)).To(Succeed())
 		})
 
-		When("creating FAR CR", func() {
-			It("should build the exec command based on FAR CR", func() {
-				Eventually(func() (bool, error) {
-					res, err := cliCommandsEquality(underTestFAR)
-					return res, err
-				}, 1*time.Second, 500*time.Millisecond).Should(BeTrue())
+		When("creating valid FAR CR", func() {
+			BeforeEach(func() {
+				node = getNode(node01)
+				underTestFAR = getFenceAgentsRemediation(node01, fenceAgentIPMI, testShareParam, testNodeParam)
+			})
+			It("should have finalizer and taint", func() {
+				farNamespacedName := client.ObjectKey{Name: node01, Namespace: defaultNamespace}
+				nodeNamespacedName := client.ObjectKey{Name: node01}
+				FARNoExecuteTaint := utils.CreateFARNoExecuteTaint()
+				Eventually(func() bool {
+					Expect(k8sClient.Get(context.Background(), nodeNamespacedName, node)).To(Succeed())
+					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
+					res, _ := cliCommandsEquality(underTestFAR)
+					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer) && utils.TaintExists(node.Spec.Taints, &FARNoExecuteTaint) && res
+				}, 1*time.Second, 500*time.Millisecond).Should(BeTrue(), "finalizer and taint should be added, and command format is correct")
+			})
+		})
+		When("creating invalid FAR CR Name", func() {
+			BeforeEach(func() {
+				node = getNode(node01)
+				underTestFAR = getFenceAgentsRemediation(dummyNode, fenceAgentIPMI, testShareParam, testNodeParam)
+			})
+			It("should fail", func() {
+				By("Not finding a matching node to FAR CR's name")
+				nodeNamespacedName := client.ObjectKey{Name: dummyNode}
+				Expect(k8sClient.Get(context.Background(), nodeNamespacedName, node)).To(Not(Succeed()))
+				By("Not having finalizer and no taints were added")
+				farNamespacedName := client.ObjectKey{Name: dummyNode, Namespace: defaultNamespace}
+				FARNoExecuteTaint := utils.CreateFARNoExecuteTaint()
+				Eventually(func() bool {
+					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
+					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer) || utils.TaintExists(node.Spec.Taints, &FARNoExecuteTaint)
+				}, 1*time.Second, 500*time.Millisecond).Should(BeFalse(), "finalizer shouldn't be added, and node shouldn't be exicted")
 			})
 		})
 	})
 })
 
 // newFenceAgentsRemediation assigns the input to the FenceAgentsRemediation
-func newFenceAgentsRemediation(nodeName string, agent string, sharedparameters map[v1alpha1.ParameterName]string, nodeparameters map[v1alpha1.ParameterName]map[v1alpha1.NodeName]string) *v1alpha1.FenceAgentsRemediation {
+func getFenceAgentsRemediation(nodeName string, agent string, sharedparameters map[v1alpha1.ParameterName]string, nodeparameters map[v1alpha1.ParameterName]map[v1alpha1.NodeName]string) *v1alpha1.FenceAgentsRemediation {
 	return &v1alpha1.FenceAgentsRemediation{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeName, Namespace: defaultNamespace},
 		Spec: v1alpha1.FenceAgentsRemediationSpec{

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	fenceagentsv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
 	"github.com/medik8s/fence-agents-remediation/controllers"
 
 	//+kubebuilder:scaffold:imports
@@ -51,7 +51,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(fenceagentsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -5,15 +5,22 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// getNodeWithName returns a node with a name nodeName, or an error if it can't be found
+func getNodeWithName(r client.Reader, nodeName string) (*corev1.Node, error) {
+	node := &corev1.Node{}
+	key := client.ObjectKey{Name: nodeName}
+	if err := r.Get(context.TODO(), key, node); err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
 // IsNodeNameValid returns an error if nodeName doesn't match any node name int the cluster, otherwise a nil
 func IsNodeNameValid(r client.Reader, nodeName string) (bool, error) {
-	node := &corev1.Node{}
-	objNodeName := types.NamespacedName{Name: nodeName}
-	err := r.Get(context.Background(), objNodeName, node)
+	_, err := getNodeWithName(r, nodeName)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			// In case of notFound API error we don't return error, since it is valid result

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -1,0 +1,110 @@
+package utils
+
+// Copy paste from SNR - https://github.com/medik8s/self-node-remediation/blob/main/pkg/utils/taints.go
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+)
+
+var (
+	loggerTaint = ctrl.Log.WithName("taints")
+)
+
+// taintExists checks if the given taint exists in list of taints. Returns true if exists false otherwise.
+func taintExists(taints []corev1.Taint, taintToFind *corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.MatchTaint(taintToFind) {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteTaint removes all the taints that have the same key and effect to given taintToDelete.
+func deleteTaint(taints []corev1.Taint, taintToDelete *corev1.Taint) ([]corev1.Taint, bool) {
+	var newTaints []corev1.Taint
+	deleted := false
+	for i := range taints {
+		if taintToDelete.MatchTaint(&taints[i]) {
+			deleted = true
+			continue
+		}
+		newTaints = append(newTaints, taints[i])
+	}
+	return newTaints, deleted
+}
+
+// createNoExecuteTaint returns a remediation NoExeucte taint
+func createNoExecuteTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    v1alpha1.Medik8sRemediationTaintKey,
+		Value:  v1alpha1.FARRemediationTaintValue,
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}
+
+// AppendTaint appends new taint to the taint list when it is not present, and returns error if it fails in the process
+func AppendTaint(r client.Client, nodeName string) error {
+	// find node by name
+	node, err := getNodeWithName(r, nodeName)
+	if err != nil {
+		return err
+	}
+
+	taint := createNoExecuteTaint()
+	// check if taint doesn't exist
+	if taintExists(node.Spec.Taints, &taint) {
+		return nil
+	}
+	// add the taint to the taint list
+	patch := client.MergeFrom(node.DeepCopy())
+	now := metav1.Now()
+	taint.TimeAdded = &now
+	node.Spec.Taints = append(node.Spec.Taints, taint)
+
+	// update with new taint list
+	if err := r.Patch(context.Background(), node, patch); err != nil {
+		loggerTaint.Error(err, "Failed to append taint on node", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+		return err
+	}
+	loggerTaint.Info("Taint was added", "taint effect", taint.Effect, "taint list", node.Spec.Taints)
+	return nil
+}
+
+// RemoveTaint removes taint from the taint list when it is existed, and returns error if it fails in the process
+func RemoveTaint(r client.Client, nodeName string) error {
+	// find node by name
+	node, err := getNodeWithName(r, nodeName)
+	if err != nil {
+		return err
+	}
+
+	taint := createNoExecuteTaint()
+	// check if taint exist
+	if !taintExists(node.Spec.Taints, &taint) {
+		return nil
+	}
+
+	// delete the taint from the taint list
+	patch := client.MergeFrom(node.DeepCopy())
+	if taints, deleted := deleteTaint(node.Spec.Taints, &taint); !deleted {
+		loggerTaint.Info("Failed to remove taint from node - taint was not found", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+		return nil
+	} else {
+		node.Spec.Taints = taints
+	}
+
+	// update with new taint list
+	if err := r.Patch(context.Background(), node, patch); err != nil {
+		loggerTaint.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+		return err
+	}
+	loggerTaint.Info("Taint was removed", "taint effect", taint.Effect, "taint list", node.Spec.Taints)
+	return nil
+}

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -65,13 +65,12 @@ func AppendTaint(r client.Client, nodeName string) error {
 		return nil
 	}
 	// add the taint to the taint list
-	patch := client.MergeFrom(node.DeepCopy())
 	now := metav1.Now()
 	taint.TimeAdded = &now
 	node.Spec.Taints = append(node.Spec.Taints, taint)
 
 	// update with new taint list
-	if err := r.Patch(context.Background(), node, patch); err != nil {
+	if err := r.Update(context.Background(), node); err != nil {
 		loggerTaint.Error(err, "Failed to append taint on node", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
 		return err
 	}
@@ -94,7 +93,6 @@ func RemoveTaint(r client.Client, nodeName string) error {
 	}
 
 	// delete the taint from the taint list
-	patch := client.MergeFrom(node.DeepCopy())
 	if taints, deleted := deleteTaint(node.Spec.Taints, &taint); !deleted {
 		loggerTaint.Info("Failed to remove taint from node - taint was not found", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
 		return nil
@@ -103,7 +101,7 @@ func RemoveTaint(r client.Client, nodeName string) error {
 	}
 
 	// update with new taint list
-	if err := r.Patch(context.Background(), node, patch); err != nil {
+	if err := r.Update(context.Background(), node); err != nil {
 		loggerTaint.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
 		return err
 	}

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -19,8 +19,8 @@ var (
 // Taints are unique by key:effect
 // Regardless of the taint's value
 
-// taintExists checks if the given taint exists in list of taints. Returns true if exists false otherwise.
-func taintExists(taints []corev1.Taint, taintToFind *corev1.Taint) bool {
+// TaintExists checks if the given taint exists in list of taints. Returns true if exists false otherwise.
+func TaintExists(taints []corev1.Taint, taintToFind *corev1.Taint) bool {
 	for _, taint := range taints {
 		if taint.MatchTaint(taintToFind) {
 			return true
@@ -43,8 +43,8 @@ func deleteTaint(taints []corev1.Taint, taintToDelete *corev1.Taint) ([]corev1.T
 	return newTaints, deleted
 }
 
-// createFARNoExecuteTaint returns a remediation NoExeucte taint
-func createFARNoExecuteTaint() corev1.Taint {
+// CreateFARNoExecuteTaint returns a remediation NoExeucte taint
+func CreateFARNoExecuteTaint() corev1.Taint {
 	return corev1.Taint{
 		Key:    v1alpha1.FARNoExecuteTaintKey,
 		Effect: corev1.TaintEffectNoExecute,
@@ -59,9 +59,9 @@ func AppendTaint(r client.Client, nodeName string) error {
 		return err
 	}
 
-	taint := createFARNoExecuteTaint()
+	taint := CreateFARNoExecuteTaint()
 	// check if taint doesn't exist
-	if taintExists(node.Spec.Taints, &taint) {
+	if TaintExists(node.Spec.Taints, &taint) {
 		return nil
 	}
 	// add the taint to the taint list
@@ -86,9 +86,9 @@ func RemoveTaint(r client.Client, nodeName string) error {
 		return err
 	}
 
-	taint := createFARNoExecuteTaint()
+	taint := CreateFARNoExecuteTaint()
 	// check if taint exist
-	if !taintExists(node.Spec.Taints, &taint) {
+	if !TaintExists(node.Spec.Taints, &taint) {
 		return nil
 	}
 

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -1,6 +1,6 @@
 package utils
 
-// Copy paste from SNR - https://github.com/medik8s/self-node-remediation/blob/main/pkg/utils/taints.go
+// Inspired from SNR - https://github.com/medik8s/self-node-remediation/blob/main/pkg/utils/taints.go
 import (
 	"context"
 
@@ -15,6 +15,9 @@ import (
 var (
 	loggerTaint = ctrl.Log.WithName("taints")
 )
+
+// Taints are unique by key:effect
+// Regardless of the taint's value
 
 // taintExists checks if the given taint exists in list of taints. Returns true if exists false otherwise.
 func taintExists(taints []corev1.Taint, taintToFind *corev1.Taint) bool {
@@ -40,11 +43,10 @@ func deleteTaint(taints []corev1.Taint, taintToDelete *corev1.Taint) ([]corev1.T
 	return newTaints, deleted
 }
 
-// createNoExecuteTaint returns a remediation NoExeucte taint
-func createNoExecuteTaint() corev1.Taint {
+// createFARNoExecuteTaint returns a remediation NoExeucte taint
+func createFARNoExecuteTaint() corev1.Taint {
 	return corev1.Taint{
-		Key:    v1alpha1.Medik8sRemediationTaintKey,
-		Value:  v1alpha1.FARRemediationTaintValue,
+		Key:    v1alpha1.FARNoExecuteTaintKey,
 		Effect: corev1.TaintEffectNoExecute,
 	}
 }
@@ -57,7 +59,7 @@ func AppendTaint(r client.Client, nodeName string) error {
 		return err
 	}
 
-	taint := createNoExecuteTaint()
+	taint := createFARNoExecuteTaint()
 	// check if taint doesn't exist
 	if taintExists(node.Spec.Taints, &taint) {
 		return nil
@@ -85,7 +87,7 @@ func RemoveTaint(r client.Client, nodeName string) error {
 		return err
 	}
 
-	taint := createNoExecuteTaint()
+	taint := createFARNoExecuteTaint()
 	// check if taint exist
 	if !taintExists(node.Spec.Taints, &taint) {
 		return nil

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -49,29 +49,8 @@ var _ = Describe("FAR E2e", func() {
 		fmt.Printf("\ncluster name: %s and PlatformType: %s \n", string(clusterPlatform.Name), string(clusterPlatform.Status.PlatformStatus.Type))
 	})
 
-	Context("fence agent - dummy", func() {
-		testNodeName := "dummy-node"
-		fenceAgent = fenceAgentDummyName
-
+	Context("fence agent", func() {
 		BeforeEach(func() {
-			testShareParam := map[v1alpha1.ParameterName]string{}
-			testNodeParam := map[v1alpha1.ParameterName]map[v1alpha1.NodeName]string{}
-			far = createFAR(testNodeName, fenceAgent, testShareParam, testNodeParam)
-		})
-
-		AfterEach(func() {
-			deleteFAR(far)
-		})
-
-		It("should check whether the CR has been created", func() {
-			testFarCR := &v1alpha1.FenceAgentsRemediation{}
-			Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(far), testFarCR)).To(Succeed(), "failed to get FAR CR")
-		})
-	})
-
-	Context("fence agent - non-Dummy", func() {
-		BeforeEach(func() {
-			var testNodeName string
 			nodes := &corev1.NodeList{}
 			Expect(k8sClient.List(context.Background(), nodes, &client.ListOptions{})).ToNot(HaveOccurred())
 			if len(nodes.Items) <= 1 {
@@ -80,7 +59,7 @@ var _ = Describe("FAR E2e", func() {
 			//TODO: Randomize the node selection
 			// run FA on the first node - a master node
 			nodeObj := nodes.Items[nodeIndex]
-			testNodeName = nodeObj.Name
+			testNodeName := nodeObj.Name
 			log.Info("Testing Node", "Node name", testNodeName)
 
 			switch clusterPlatform.Status.PlatformStatus.Type {


### PR DESCRIPTION
In the process of supporting workload deletion we are supporting the Medik8s remediation taint (with FAR name value), and [_NoExecute_ effect](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions):

- Adding taint support - Specifically supporting the Medik8s remediation taint, and possibly in the future more taints.
- Support the taint removal with a Finalizer
- Add two RBAC verbs on node resource (`delete`, and `update`) - It is needed for adding and removing taint on a cluster node.
- Remove redundant dummy E2E test
- Addition/removal of taint or finalizer will only be handled after Node-CR validation 
- UT for valid and invalid Node-CR 

[ECOPROJECT-1321](https://issues.redhat.com//browse/ECOPROJECT-1321) and [ECOPROJECT-1322](https://issues.redhat.com//browse/ECOPROJECT-1322)