### PR TITLE
Support Only reboot Action

### DIFF
--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -158,7 +158,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Fence Agent response was a failure", "CR's Name", req.Name)
 		return emptyResult, err
 	}
-	if outputErr != "" || outputRes == "" {
+	if outputErr != "" || outputRes != SuccessFAResponse {
 		// response wasn't failure or sucesss message
 		err := fmt.Errorf("unknown fence agent response - expecting `%s` response, but we received `%s`", SuccessFAResponse, outputRes)
 		r.Log.Error(err, "Fence Agent response wasn't a success message", "CR's Name", req.Name)

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -141,8 +141,8 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 	r.Log.Info("Combine fence agent parameters", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)
 	faParams, err := buildFenceAgentParams(far)
 	if err != nil {
-		r.Log.Error(err, "Invalid sharedParameters/nodeParameters from CR", "CR's Name", req.Name)
-		return emptyResult, err
+		r.Log.Error(err, "Invalid sharedParameters/nodeParameters from CR - edit/recreate the CR", "CR's Name", req.Name)
+		return emptyResult, nil
 	}
 	// Add medik8s remediation taint
 	r.Log.Info("Add Medik8s remediation taint", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)
@@ -158,7 +158,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Fence Agent response was a failure", "CR's Name", req.Name)
 		return emptyResult, err
 	}
-	if outputErr != "" || outputRes != SuccessFAResponse {
+	if outputErr != "" || outputRes != SuccessFAResponse+"\n" {
 		// response wasn't failure or sucesss message
 		err := fmt.Errorf("unknown fence agent response - expecting `%s` response, but we received `%s`", SuccessFAResponse, outputRes)
 		r.Log.Error(err, "Fence Agent response wasn't a success message", "CR's Name", req.Name)
@@ -168,7 +168,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 }
 
 // buildFenceAgentParams collects the FAR's parameters for the node based on FAR CR, and if the CR is missing parameters
-// or the CR's name don't match nodeParamter name then return an error
+// or the CR's name don't match nodeParamter name or it has an action which is different than reboot, then return an error
 func buildFenceAgentParams(far *v1alpha1.FenceAgentsRemediation) ([]string, error) {
 	logger := ctrl.Log.WithName("build-fa-parameters")
 	if far.Spec.NodeParameters == nil || far.Spec.SharedParameters == nil {
@@ -182,10 +182,15 @@ func buildFenceAgentParams(far *v1alpha1.FenceAgentsRemediation) ([]string, erro
 		if paramName != parameterActionName {
 			fenceAgentParams = appendParamToSlice(fenceAgentParams, paramName, paramVal)
 		} else if paramVal != parameterActionValue {
-			logger.Info("FAR doesn't support any other action than reboot", "action", paramVal)
+			// --action attribute was selected but it is differemt than reboot
+			err := errors.New("FAR doesn't support any other action than reboot")
+			logger.Error(err, "can't build CR with this action attribute", "action", paramVal)
+			return nil, err
 		}
 	}
-	// ensure the FA uses the reboot action
+	// if --action attribute was not selected, then it's default value is reboot
+	// https://github.com/ClusterLabs/fence-agents/blob/main/lib/fencing.py.py#L103
+	// Therefore we can safely add the reboot action regardless if it was initially added into the CR
 	fenceAgentParams = appendParamToSlice(fenceAgentParams, parameterActionName, parameterActionValue)
 
 	// append node parameters

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -55,7 +55,6 @@ var _ = Describe("FAR Controller", func() {
 	invalidShareParam := map[v1alpha1.ParameterName]string{
 		"--username": "admin",
 		"--password": "password",
-		"--action":   "",
 		"--ip":       "192.168.111.1",
 		"--lanplus":  "",
 	}

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -107,7 +107,7 @@ var _ = Describe("FAR E2e", func() {
 				checkRemediation(nodeName, nodeBootTimeBefore)
 			})
 			It("should successfully remediate the second node", func() {
-				checkRemediation(nodeName,nodeBootTimeBefore)
+				checkRemediation(nodeName, nodeBootTimeBefore)
 			})
 		})
 	})

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/controllers"
 	"github.com/medik8s/fence-agents-remediation/pkg/utils"
 	e2eUtils "github.com/medik8s/fence-agents-remediation/test/e2e/utils"
 )
@@ -30,7 +31,6 @@ const (
 	fenceAgentAction         = "reboot"
 	nodeIdentifierPrefixAWS  = "--plug"
 	nodeIdentifierPrefixIPMI = "--ipport"
-	succeesRebootMessage     = "\"Success: Rebooted"
 	containerName            = "manager"
 
 	//TODO: try to minimize timeout
@@ -104,11 +104,10 @@ var _ = Describe("FAR E2e", func() {
 		})
 		When("running FAR to reboot two nodes", func() {
 			It("should successfully remediate the first node", func() {
-				checkRemediation(nodeName, succeesRebootMessage, nodeBootTimeBefore)
+				checkRemediation(nodeName, nodeBootTimeBefore)
 			})
 			It("should successfully remediate the second node", func() {
-				checkRemediation(nodeName, succeesRebootMessage, nodeBootTimeBefore)
-
+				checkRemediation(nodeName,nodeBootTimeBefore)
 			})
 		})
 	})
@@ -293,7 +292,7 @@ func wasNodeRebooted(nodeName string, nodeBootTimeBefore time.Time) {
 }
 
 // checkRemediation verify whether the node was remediated
-func checkRemediation(nodeName, logString string, nodeBootTimeBefore time.Time) {
+func checkRemediation(nodeName string, nodeBootTimeBefore time.Time) {
 	By("Check if FAR NoExecute taint was added")
 	wasFarTaintAdded(nodeName)
 
@@ -301,7 +300,7 @@ func checkRemediation(nodeName, logString string, nodeBootTimeBefore time.Time) 
 	// TODO: When reboot is running only once and it is running on FAR node, then FAR pod will
 	// be recreated on a new node and since the FA command won't be exuected again, then the log
 	// won't include any success message
-	checkFarLogs(succeesRebootMessage)
+	checkFarLogs(controllers.SuccessFAResponse)
 
 	By("Getting new node's boot time")
 	wasNodeRebooted(nodeName, nodeBootTimeBefore)


### PR DESCRIPTION
Support only **`reboot`** action - we build the FA command with  _reboot_ action, when `--action` equals to reboot or this attribute is missing (since reboot is the [default action](https://github.com/ClusterLabs/fence-agents/blob/main/lib/fencing.py.py#L103)), otherwise we return an error and end reconcile

[ECOPROJECT-1323](https://issues.redhat.com//browse/ECOPROJECT-1323)

EDIT: Another valid action use case could be the **off** which ensure fencing, just without recovering the node. When then the admin/user will be responsible to turn the node on (or to recover the node) after a possible further investigation.