### PR TITLE
Fence Agent Output Check

### DIFF
--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -77,7 +77,7 @@ var _ = Describe("FAR Controller", func() {
 					underTestFAR.ObjectMeta.Name = dummyNodeName
 					_, err := buildFenceAgentParams(underTestFAR)
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(Equal(errors.New(errorBuildingFAParams)))
+					Expect(err).To(Equal(errors.New(errorMissingNodeParams)))
 				})
 			})
 			When("FAR CR's name does match a node name", func() {
@@ -200,5 +200,5 @@ func newMockExecuter() *mockExecuter {
 func (m *mockExecuter) Execute(_ *corev1.Pod, command []string) (stdout string, stderr string, err error) {
 	m.command = command
 	m.mockLog.Info("Executed command has been stored", "command", m.command)
-	return "", "", nil
+	return SuccessFAResponse, "", nil
 }

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -83,8 +83,7 @@ var _ = Describe("FAR Controller", func() {
 			When("FAR CR's name does match a node name", func() {
 				It("should succeed", func() {
 					underTestFAR.ObjectMeta.Name = validNodeName
-					_, err := buildFenceAgentParams(underTestFAR)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(buildFenceAgentParams(underTestFAR)).Error().NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -89,9 +89,9 @@ func (e executer) Execute(pod *corev1.Pod, command []string) (stdout string, std
 		Tty:    false,
 	})
 	if err != nil {
-		e.log.Error(err, "Failed to run exec command", "command", command, "stdout", stdoutBuf.String(), "stderr", stderrBuf.String())
+		e.log.Error(err, "Failed to run exec command", "stdout", stdoutBuf.String(), "stderr", stderrBuf.String())
 	} else {
-		e.log.Info("Command has been executed successfully", "command", command, "standard output", stdoutBuf.String())
+		e.log.Info("Command has been executed successfully", "stdout", stdoutBuf.String())
 	}
 	return stdoutBuf.String(), stderrBuf.String(), err
 }


### PR DESCRIPTION
1. Don't log (and expose) FA command - It might include privileged credentials that an attacker can manipulate and abuse.
2. Check fence agent CLI output - Error and expected success output.
3. Small improvement to UT check - https://github.com/medik8s/fence-agents-remediation/pull/48#discussion_r1222721600
4. Add log.error in Reconcile for better identification of error's source/root.

[ECOPROJECT-1329](https://issues.redhat.com//browse/ECOPROJECT-1329)