### PR TITLE
Update to Golang v1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM quay.io/centos/centos:stream8 AS builder
 RUN dnf install -y golang git \
     && dnf clean all -y
 
-# Ensure correct Go version
-ENV GO_VERSION=1.18
-RUN go install golang.org/dl/go${GO_VERSION}@latest \
-    && ~/go/bin/go${GO_VERSION} download \
-    && /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go \
-    && go version
-
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+# Ensure correct Go version
+RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
+    go install golang.org/dl/go${GO_VERSION}@latest && \
+    ~/go/bin/go${GO_VERSION} download && \
+    /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go && \
+    go version
 
 # Copy the go source
 COPY main.go main.go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/medik8s/fence-agents-remediation
 
-go 1.18
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
- Update Golang [v1.18](https://go.dev/blog/go1.18)-> [v1.20](https://go.dev/blog/go1.20)
- Ensure Dockerfile use a matching Golang version
- Set Golang image for CI in FAR's repo rather than in [FAR CI repo](https://github.com/openshift/release/tree/master/ci-operator/config/medik8s/fence-agents-remediation).

Similar to [#76 PR](https://github.com/medik8s/machine-deletion-remediation/pull/76) of MDR