### PR TITLE
Improving Unit Test Logic and Time

### DIFF
--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -139,7 +139,7 @@ var _ = Describe("FAR Controller", func() {
 					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
 					res, _ := cliCommandsEquality(underTestFAR)
 					return utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint) && res
-				}, 1*time.Second, 500*time.Millisecond).Should(BeTrue(), "taint should be added, and command format is correct")
+				}, 20*time.Millisecond, 10*time.Millisecond).Should(BeTrue(), "taint should be added, and command format is correct")
 				// If taint was added, then defenintly the finzlier was added as well
 				By("Having a finalizer if we have a remediation taint")
 				Expect(controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer)).To(BeTrue())
@@ -160,7 +160,7 @@ var _ = Describe("FAR Controller", func() {
 				Eventually(func() bool {
 					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
 					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer)
-				}, 1*time.Second, 500*time.Millisecond).Should(BeFalse(), "finalizer shouldn't be added")
+				}, 20*time.Millisecond, 10*time.Millisecond).Should(BeFalse(), "finalizer shouldn't be added")
 				// If finalizer is missing, then a taint shouldn't be existed
 				By("Not having remediation taint")
 				Expect(utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint)).To(BeFalse())

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -120,10 +120,10 @@ var _ = Describe("FAR Controller", func() {
 		})
 		JustBeforeEach(func() {
 			// DeferCleanUp and Create node, and FAR CR
-			DeferCleanup(k8sClient.Delete, context.Background(), node)
-			DeferCleanup(k8sClient.Delete, context.Background(), underTestFAR)
 			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, context.Background(), node)
 			Expect(k8sClient.Create(context.Background(), underTestFAR)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, context.Background(), underTestFAR)
 		})
 
 		When("creating valid FAR CR", func() {
@@ -133,12 +133,17 @@ var _ = Describe("FAR Controller", func() {
 			It("should have finalizer and taint", func() {
 				farNamespacedName := client.ObjectKey{Name: node01, Namespace: defaultNamespace}
 				nodeNamespacedName := client.ObjectKey{Name: node01}
+				By("Searching for remediation taint")
 				Eventually(func() bool {
 					Expect(k8sClient.Get(context.Background(), nodeNamespacedName, node)).To(Succeed())
 					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
 					res, _ := cliCommandsEquality(underTestFAR)
-					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer) && utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint) && res
-				}, 1*time.Second, 500*time.Millisecond).Should(BeTrue(), "finalizer and taint should be added, and command format is correct")
+					return utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint) && res
+				}, 1*time.Second, 500*time.Millisecond).Should(BeTrue(), "taint should be added, and command format is correct")
+				// If taint was added, then defenintly the finzlier was added as well
+				By("Having a finalizer if we have a remediation taint")
+				Expect(controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer)).To(BeTrue())
+
 			})
 		})
 		When("creating invalid FAR CR Name", func() {
@@ -146,16 +151,19 @@ var _ = Describe("FAR Controller", func() {
 				node = getNode(node01)
 				underTestFAR = getFenceAgentsRemediation(dummyNode, fenceAgentIPMI, testShareParam, testNodeParam)
 			})
-			It("should fail", func() {
+			It("should not have a finalizer nor taint", func() {
 				By("Not finding a matching node to FAR CR's name")
 				nodeNamespacedName := client.ObjectKey{Name: dummyNode}
 				Expect(k8sClient.Get(context.Background(), nodeNamespacedName, node)).To(Not(Succeed()))
-				By("Not having finalizer and no taints were added")
+				By("Not having finalizer")
 				farNamespacedName := client.ObjectKey{Name: dummyNode, Namespace: defaultNamespace}
 				Eventually(func() bool {
 					Expect(k8sClient.Get(context.Background(), farNamespacedName, underTestFAR)).To(Succeed())
-					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer) || utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint)
-				}, 1*time.Second, 500*time.Millisecond).Should(BeFalse(), "finalizer shouldn't be added, and node shouldn't be exicted")
+					return controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer)
+				}, 1*time.Second, 500*time.Millisecond).Should(BeFalse(), "finalizer shouldn't be added")
+				// If finalizer is missing, then a taint shouldn't be existed
+				By("Not having remediation taint")
+				Expect(utils.TaintExists(node.Spec.Taints, &farNoExecuteTaint)).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
1. Separate logical unit-test and order- Test _taint_ and _finalizer_ existence in eventually following an expect rather than one eventually with and a logical OR/AND of there existence. This way we better check the order of their creation. Related to [older comment](https://github.com/medik8s/fence-agents-remediation/pull/53#discussion_r1234149421).
2. Reduce eventually timeout and polling interval- the values were too high