### PR TITLE
Validate utils Package and Taint Functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ test: test-no-verify verify-unchanged ## Generate and format code, run tests, ge
 # --require-suite: If set, Ginkgo fails if there are ginkgo tests in a directory but no invocation of RunSpecs.
 # --vv: If set, emits with maximal verbosity - includes skipped and pending tests.
 test-no-verify: manifests generate go-verify fmt vet fix-imports envtest ginkgo # Generate and format code, and run tests
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR)/$(ENVTEST_VERSION) -p path)"  $(GINKGO) -r --keep-going --require-suite --vv -coverprofile cover.out ./controllers
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR)/$(ENVTEST_VERSION) -p path)" \
+	$(GINKGO) -r --keep-going --require-suite --vv -coverprofile cover.out ./controllers/... ./pkg/...
 
 .PHONY: bundle-run
 export BUNDLE_RUN_NAMESPACE ?= openshift-operators

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	medik8sLabels "github.com/medik8s/common/pkg/labels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -73,10 +72,6 @@ var _ = Describe("FAR Controller", func() {
 
 	// default FenceAgentsRemediation CR
 	underTestFAR := getFenceAgentsRemediation(node01, fenceAgentIPMI, testShareParam, testNodeParam)
-	nodeKey := client.ObjectKey{Name: node01}
-	farNamespacedName := client.ObjectKey{Name: node01, Namespace: defaultNamespace}
-	controlPlaneRoleTaint := getControlPlaneRoleTaint()
-	farNoExecuteTaint := utils.CreateFARNoExecuteTaint()
 
 	Context("Functionality", func() {
 		Context("buildFenceAgentParams", func() {
@@ -95,55 +90,11 @@ var _ = Describe("FAR Controller", func() {
 				})
 			})
 		})
-
-		Context("IsNodeNameValid", func() {
-			BeforeEach(func() {
-				node = getNode("", node01)
-				DeferCleanup(k8sClient.Delete, context.Background(), node)
-				Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
-			})
-			When("FAR CR's name doesn't match to an existing node name", func() {
-				It("should fail", func() {
-					Expect(utils.IsNodeNameValid(k8sClient, dummyNode)).To(BeFalse())
-				})
-			})
-			When("FAR's name does match to an existing node name", func() {
-				It("should succeed", func() {
-					Expect(utils.IsNodeNameValid(k8sClient, node01)).To(BeTrue())
-				})
-			})
-		})
-		Context("Taint functioninality test", func() {
-			// Check functionaility with control-plane node which already has a taint
-			BeforeEach(func() {
-				node = getNode("control-plane", node01)
-				Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
-				DeferCleanup(k8sClient.Delete, context.Background(), node)
-			})
-			When("Control-plane node only has 1 the control-plane-role taint", func() {
-				It("should add and delete medik8s NoSchedule taint and keep other existing taints", func() {
-					By("having one control-plane-role taint")
-					taintedNode := &corev1.Node{}
-					Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
-					Expect(utils.TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
-					By("adding medik8s NoSchedule taint")
-					Expect(utils.AppendTaint(k8sClient, node01)).To(Succeed())
-					Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
-					Expect(utils.TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
-					Expect(utils.TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeTrue())
-					By("removing medik8s NoSchedule taint")
-					Expect(utils.RemoveTaint(k8sClient, node01)).To(Succeed())
-					Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
-					Expect(utils.TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
-					Expect(utils.TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeFalse())
-
-					// there is a not-ready taint now as well, so there will be 2 taints... skip count tests
-					// Expect(len(taintedNode.Spec.Taints)).To(Equal(1))
-				})
-			})
-		})
 	})
 	Context("Reconcile", func() {
+		nodeKey := client.ObjectKey{Name: node01}
+		farNamespacedName := client.ObjectKey{Name: node01, Namespace: defaultNamespace}
+		farNoExecuteTaint := utils.CreateFARNoExecuteTaint()
 		//Scenarios
 		BeforeEach(func() {
 			fenceAgentsPod = buildFarPod()
@@ -163,7 +114,7 @@ var _ = Describe("FAR Controller", func() {
 
 		When("creating valid FAR CR", func() {
 			BeforeEach(func() {
-				node = getNode("", node01)
+				node = utils.GetNode("", node01)
 			})
 			It("should have finalizer and taint", func() {
 				By("Searching for remediation taint")
@@ -181,7 +132,7 @@ var _ = Describe("FAR Controller", func() {
 		})
 		When("creating invalid FAR CR Name", func() {
 			BeforeEach(func() {
-				node = getNode("", node01)
+				node = utils.GetNode("", node01)
 				underTestFAR = getFenceAgentsRemediation(dummyNode, fenceAgentIPMI, testShareParam, testNodeParam)
 			})
 			It("should not have a finalizer nor taint", func() {
@@ -211,40 +162,6 @@ func getFenceAgentsRemediation(nodeName string, agent string, sharedparameters m
 			SharedParameters: sharedparameters,
 			NodeParameters:   nodeparameters,
 		},
-	}
-}
-
-// used for making new node object for test and have a unique resourceVersion
-// getNode returns a node object with the name nodeName based on the nodeType input
-func getNode(nodeType, nodeName string) *corev1.Node {
-	if nodeType == "control-plane" {
-		return &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nodeName,
-			},
-			Spec: corev1.NodeSpec{
-				Taints: []corev1.Taint{
-					{
-						Key:    medik8sLabels.ControlPlaneRole,
-						Effect: corev1.TaintEffectNoExecute,
-					},
-				},
-			},
-		}
-	} else {
-		return &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nodeName,
-			},
-		}
-	}
-}
-
-// getControlPlaneRoleTaint returns a control-plane-role taint
-func getControlPlaneRoleTaint() corev1.Taint {
-	return corev1.Taint{
-		Key:    medik8sLabels.ControlPlaneRole,
-		Effect: corev1.TaintEffectNoExecute,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4
+	github.com/medik8s/common v1.2.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/openshift/api v0.0.0-20230621174358-ea40115b9fa6

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/medik8s/common v1.2.0 h1:xgQOijD3rEn+PfCd4lJuV3WFdt5QA6SIaqF01rRp2as=
+github.com/medik8s/common v1.2.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -8,8 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const WorkerLabelName = "node-role.kubernetes.io/worker"
-
 // getNodeWithName returns a node with a name nodeName, or an error if it can't be found
 func getNodeWithName(r client.Reader, nodeName string) (*corev1.Node, error) {
 	node := &corev1.Node{}

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -35,10 +35,10 @@ func IsNodeNameValid(r client.Reader, nodeName string) (bool, error) {
 	return true, nil
 }
 
-// used for making new node object for test and have a unique resourceVersion
 // GetNode returns a node object with the name nodeName based on the nodeType input
-func GetNode(nodeType, nodeName string) *corev1.Node {
-	if nodeType == "control-plane" {
+// used for making new node object for test and have a unique resourceVersion
+func GetNode(nodeRole, nodeName string) *corev1.Node {
+	if nodeRole == "control-plane" {
 		return &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -3,8 +3,11 @@ package utils
 import (
 	"context"
 
+	medik8sLabels "github.com/medik8s/common/pkg/labels"
+
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,4 +33,30 @@ func IsNodeNameValid(r client.Reader, nodeName string) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// used for making new node object for test and have a unique resourceVersion
+// GetNode returns a node object with the name nodeName based on the nodeType input
+func GetNode(nodeType, nodeName string) *corev1.Node {
+	if nodeType == "control-plane" {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: corev1.NodeSpec{
+				Taints: []corev1.Taint{
+					{
+						Key:    medik8sLabels.ControlPlaneRole,
+						Effect: corev1.TaintEffectNoExecute,
+					},
+				},
+			},
+		}
+	} else {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+	}
 }

--- a/pkg/utils/nodes_test.go
+++ b/pkg/utils/nodes_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	dummyNode = "dummy-node"
+	node01    = "worker-0"
+)
+
+var _ = Describe("Utils-nodes", func() {
+	var node *corev1.Node
+	Context("FAR CR and Node Names Validity test", func() {
+		BeforeEach(func() {
+			node = GetNode("", node01)
+			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, context.Background(), node)
+		})
+		When("FAR CR's name doesn't match to an existing node name", func() {
+			It("should fail", func() {
+				Expect(IsNodeNameValid(k8sClient, dummyNode)).To(BeFalse())
+			})
+		})
+		When("FAR's name does match to an existing node name", func() {
+			It("should succeed", func() {
+				Expect(IsNodeNameValid(k8sClient, node01)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/utils/suite_test.go
+++ b/pkg/utils/suite_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const defaultNamespace = "default"
+
+var k8sClient client.Client
+var k8sManager manager.Manager
+var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = BeforeSuite(func() {
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
+	}
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = v1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	os.Setenv("DEPLOYMENT_NAMESPACE", defaultNamespace)
+
+	go func() {
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+		ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
+		err := k8sManager.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"context"
+
+	medik8sLabels "github.com/medik8s/common/pkg/labels"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	dummyNode = "dummy-node"
+	node01    = "worker-0"
+)
+
+var _ = Describe("Utils", func() {
+	var node *corev1.Node
+	nodeKey := client.ObjectKey{Name: node01}
+	controlPlaneRoleTaint := getControlPlaneRoleTaint()
+	farNoExecuteTaint := CreateFARNoExecuteTaint()
+	Context("FAR CR and Node Names Validity test", func() {
+		BeforeEach(func() {
+			node = GetNode("", node01)
+			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, context.Background(), node)
+		})
+		When("FAR CR's name doesn't match to an existing node name", func() {
+			It("should fail", func() {
+				Expect(IsNodeNameValid(k8sClient, dummyNode)).To(BeFalse())
+			})
+		})
+		When("FAR's name does match to an existing node name", func() {
+			It("should succeed", func() {
+				Expect(IsNodeNameValid(k8sClient, node01)).To(BeTrue())
+			})
+		})
+	})
+	Context("Taint functioninality test", func() {
+		// Check functionaility with control-plane node which already has a taint
+		BeforeEach(func() {
+			node = GetNode("control-plane", node01)
+			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, context.Background(), node)
+		})
+		When("Control-plane node only has 1 the control-plane-role taint", func() {
+			It("should add and delete medik8s NoSchedule taint and keep other existing taints", func() {
+				By("having one control-plane-role taint")
+				taintedNode := &corev1.Node{}
+				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
+				// control-plane-role taint already exist by GetNode
+				By("adding medik8s NoSchedule taint")
+				Expect(AppendTaint(k8sClient, node01)).To(Succeed())
+				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
+				Expect(TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
+				Expect(TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeTrue())
+				By("removing medik8s NoSchedule taint")
+				// We want to see that RemoveTaint only remove the taint it receives
+				Expect(RemoveTaint(k8sClient, node01)).To(Succeed())
+				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
+				Expect(TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
+				Expect(TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeFalse())
+
+				// there is a not-ready taint now as well, so there will be 2 taints... skip count tests
+				// Expect(len(taintedNode.Spec.Taints)).To(Equal(1))
+			})
+		})
+	})
+})
+
+// getControlPlaneRoleTaint returns a control-plane-role taint
+func getControlPlaneRoleTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    medik8sLabels.ControlPlaneRole,
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	medik8sLabels "github.com/medik8s/common/pkg/labels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -64,7 +65,7 @@ var _ = Describe("FAR E2e", func() {
 		BeforeEach(func() {
 			nodes := &corev1.NodeList{}
 			selector := labels.NewSelector()
-			requirement, _ := labels.NewRequirement(utils.WorkerLabelName, selection.Exists, []string{})
+			requirement, _ := labels.NewRequirement(medik8sLabels.WorkerRole, selection.Exists, []string{})
 			selector = selector.Add(*requirement)
 			Expect(k8sClient.List(context.Background(), nodes, &client.ListOptions{LabelSelector: selector})).ToNot(HaveOccurred())
 			if len(nodes.Items) < 1 {

--- a/vendor/github.com/medik8s/common/LICENSE
+++ b/vendor/github.com/medik8s/common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/medik8s/common/pkg/labels/labels.go
+++ b/vendor/github.com/medik8s/common/pkg/labels/labels.go
@@ -1,0 +1,10 @@
+package labels
+
+const (
+	// WorkerRole is the role label of worker nodes
+	WorkerRole = "node-role.kubernetes.io/worker"
+	// MasterRole is the old role label of control plane nodes
+	MasterRole = "node-role.kubernetes.io/master"
+	// ControlPlaneRole is the new role label of control plane nodes
+	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -92,6 +92,9 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.4
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
+# github.com/medik8s/common v1.2.0
+## explicit; go 1.20
+github.com/medik8s/common/pkg/labels
 # github.com/moby/spdystream v0.2.0
 ## explicit; go 1.13
 github.com/moby/spdystream


### PR DESCRIPTION
- Add one unit test for taint functionality on control-plane node with adding and removing FAR NoExecute taint
- Use worker label from Commons rather than declaring it in FAR's repoistory
- Run `make go-verify`
- Create new suite test and UT file for utils package, then move out the 3 UT for Utils functionality to utils_test, and update makefile to test the new directory.