### PR TITLE
End Reconcile after Finalizer Addition

### DIFF
--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -106,6 +106,10 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		if err := r.Client.Update(context.Background(), far); err != nil {
 			return emptyResult, fmt.Errorf("failed to add finalizer to the CR - %w", err)
 		}
+		r.Log.Info("Finalizer was added", "CR Name", req.Name)
+		return emptyResult, nil
+		// TODO: should return Requeue: true when the CR has a status and not end reconcile with empty result when a finalizer has been added
+		//return ctrl.Result{Requeue: true}, nil
 	} else if controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) && !far.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Delete CR only when a finalizer and DeletionTimestamp are set
 		r.Log.Info("CR's deletion timestamp is not zero, and FAR finalizer exists", "CR Name", req.Name)


### PR DESCRIPTION
The reconcile should end when a finalizer has been added. Without ending the reconcile a new reconcile will always be triggered and will result in a duplicate reboot to the node (until FAR would have a status to the CR).

[ECOPROJECT-1415](https://issues.redhat.com//browse/ECOPROJECT-1415)