### PR TITLE
test-e2e target for any platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,6 @@ ocp-aws-credentials: ## Add CredentialsRequest for OCP on AWS
 # --keep-going:  If set, failures from earlier test suites do not prevent later test suites from running.
 # --require-suite: If set, Ginkgo fails if there are ginkgo tests in a directory but no invocation of RunSpecs.
 # --vv: If set, emits with maximal verbosity - includes skipped and pending tests.
-test-e2e: ocp-aws-credentials ginkgo ## Run end to end (E2E) tests
+test-e2e: ginkgo ## Run end to end (E2E) tests
 	@test -n "${KUBECONFIG}" -o -r ${HOME}/.kube/config || (echo "Failed to find kubeconfig in ~/.kube/config or no KUBECONFIG set"; exit 1)
 	$(GINKGO) -r --keep-going --require-suite --vv  ./test/e2e -coverprofile cover.out


### PR DESCRIPTION
The `ocp-aws-credentials` target uses kubectl create to add CredentialsRequest CR for AWS platform.
The `test-e2e` uses the `ocp-aws-credentials` target even though the E2E tests can run on different platforms and when we run it twice then, the target will fail on a second try of `test-e2e`, since the CredentialsRequest CR already exist.

I usually test the E2E on Baremetal platform, and sometimes on AWS.