### PR TITLE
Add priorityClassName to the Manager Container

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -267,6 +267,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+              priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         runAsNonRoot: true
+      priorityClassName: system-cluster-critical
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Help the scheduler to understand the pod's priority versus other pods to be scheduled.

priorityClassName for other Medik8s operators:

- NHC - [`system-cluster-critical`](https://github.com/medik8s/node-healthcheck-operator/blob/055036c59515bbfc1a5a73a65fdceaf2a2f0470c/config/manager/manager.yaml#L47)
- NMO - [`system-cluster-critical` ](https://github.com/medik8s/node-maintenance-operator/blob/b45101c42b75f4ddd41c71623ebb37dc46d7cc5b/config/manager/manager.yaml#L44)
- SNR - [`system-cluster-critical`](https://github.com/medik8s/self-node-remediation/blob/b7042da262c6d00b119445d6b97c61ea55e6fd57/config/manager/manager.yaml#L27)

Related links:

- Pod Priority in Kubernetes - https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
- priorityClassName in OpenShift - https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-priority.html
- Three priorityClassName conventions -  https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#priority-classes