### PR TITLE
Set Node Unhealthy in E2E by Stopping Kubelet

### DIFF
--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -79,13 +79,12 @@ var _ = Describe("FAR E2e", func() {
 
 	Context("stress cluster", func() {
 		var (
-			nodes, filteredNodes *corev1.NodeList
-			nodeName             string
+			nodes, filteredNodes                *corev1.NodeList
+			nodeName                            string
 			va                                  *storagev1.VolumeAttachment
 			pod                                 *corev1.Pod
 			creationTimePod, nodeBootTimeBefore time.Time
-			err                  error
-
+			err                                 error
 		)
 		BeforeEach(func() {
 			nodes = &corev1.NodeList{}

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -28,10 +28,21 @@ const (
 	containerTestName = "test-command"
 )
 
+// StopKubelet runs cmd connand to stop kubelet for the node and returns an error only if it fails
+func StopKubelet(c *kubernetes.Clientset, nodeName string, testNsName string, log logr.Logger) error {
+	cmd := "microdnf install util-linux -y && /usr/bin/nsenter -m/proc/1/ns/mnt /bin/systemctl stop kubelet"
+	_, err := runCommandInCluster(c, nodeName, testNsName, cmd, log)
+	if err != nil && strings.Contains(err.Error(), "connection refused") {
+		log.Info("ignoring expected error when stopping kubelet", "error", err.Error())
+		return nil
+	}
+	return err
+}
+
 // GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
 func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (time.Time, error) {
 	emptyTime := time.Time{}
-	output, err := RunCommandInCluster(c, nodeName, ns, "microdnf install procps -y >/dev/null 2>&1 && uptime -s", log)
+	output, err := runCommandInCluster(c, nodeName, ns, "microdnf install procps -y >/dev/null 2>&1 && uptime -s", log)
 	if err != nil {
 		return emptyTime, err
 	}
@@ -44,8 +55,8 @@ func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.L
 	return bootTime, nil
 }
 
-// RunCommandInCluster runs a command in a pod in the cluster and returns the output
-func RunCommandInCluster(c *kubernetes.Clientset, nodeName string, ns string, command string, log logr.Logger) (string, error) {
+// runCommandInCluster runs a command in a pod in the cluster and returns the output
+func runCommandInCluster(c *kubernetes.Clientset, nodeName string, ns string, command string, log logr.Logger) (string, error) {
 
 	// create a pod and wait that it's running
 	pod := GetPod(nodeName, containerTestName)

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -28,7 +28,7 @@ const (
 	containerTestName = "test-command"
 )
 
-// StopKubelet runs cmd connand to stop kubelet for the node and returns an error only if it fails
+// StopKubelet runs cmd command to stop kubelet for the node and returns an error only if it fails
 func StopKubelet(c *kubernetes.Clientset, nodeName string, testNsName string, log logr.Logger) error {
 	cmd := "microdnf install util-linux -y && /usr/bin/nsenter -m/proc/1/ns/mnt /bin/systemctl stop kubelet"
 	_, err := runCommandInCluster(c, nodeName, testNsName, cmd, log)
@@ -39,7 +39,7 @@ func StopKubelet(c *kubernetes.Clientset, nodeName string, testNsName string, lo
 	return err
 }
 
-// GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
+// GetBootTime returns the node's boot time, otherwise it fails and returns an error
 func GetBootTime(c *kubernetes.Clientset, nodeName string, ns string, log logr.Logger) (time.Time, error) {
 	emptyTime := time.Time{}
 	output, err := runCommandInCluster(c, nodeName, ns, "microdnf install procps -y >/dev/null 2>&1 && uptime -s", log)


### PR DESCRIPTION
The E2E test should emphasize a realistic scenario of only when a node is unhealthy FAR CR should be created. We achieve that by stopping kubelet on the desired node.