### PR TITLE
Improve Verification of FA Success Response

### DIFF
--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -165,6 +165,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Fence Agent response wasn't a success message", "CR's Name", req.Name)
 		return emptyResult, err
 	}
+	r.Log.Info("Fence Agent command was finished successfully", "Fence Agent", far.Spec.Agent, "Node name", req.Name, "Response", SuccessFAResponse)
 
 	// Reboot was finished and now we remove workloads (pods and their VA)
 	r.Log.Info("Manual workload deletion", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -353,15 +353,16 @@ func buildExpectedLogOutput(nodeName, successMessage string) string {
 	return expectedString
 }
 
-// checkFarLogs gets the FAR pod and checks whether it's logs have logString
-func checkFarLogs(farNodeName, logString string) {
+// checkFarLogs gets the FAR pod and checks whether it's logs have logString, and if the pod was in the unhealthyNode
+// then we don't look for the expected logString
+func checkFarLogs(unhealthyNodeName, logString string) {
 	EventuallyWithOffset(1, func() string {
 		pod, err := utils.GetFenceAgentsRemediationPod(k8sClient)
 		if err != nil {
 			log.Error(err, "failed to get FAR pod. Might try again")
 			return ""
 		}
-		if pod.Spec.NodeName == farNodeName {
+		if pod.Spec.NodeName == unhealthyNodeName {
 			// When reboot is running on FAR node, then FAR pod will be recreated on a new node
 			// and since the FA command won't be executed again, then the log won't include
 			// any success message, so we won't verfiy the FAR success message on this scenario

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -346,6 +346,13 @@ func makeNodeUnready(node *corev1.Node) {
 	log.Info("node is unready", "node name", node.GetName())
 }
 
+// buildExpectedLogOutput returns a string with a node identifier and a success message for the reboot action
+func buildExpectedLogOutput(nodeName, successMessage string) string {
+	expectedString := fmt.Sprintf("\"Node name\": \"%s\", \"Response\": \"%s", nodeName, successMessage)
+	log.Info("Substring to search in the logs", "expectedString", expectedString)
+	return expectedString
+}
+
 // checkFarLogs gets the FAR pod and checks whether it's logs have logString
 func checkFarLogs(farNodeName, logString string) {
 	EventuallyWithOffset(1, func() string {
@@ -420,7 +427,8 @@ func checkRemediation(nodeName string, nodeBootTimeBefore time.Time, oldPodCreat
 	wasFarTaintAdded(nodeName)
 
 	By("Check if the response of the FA was a success")
-	checkFarLogs(nodeName, controllers.SuccessFAResponse)
+	expectedLog := buildExpectedLogOutput(nodeName, controllers.SuccessFAResponse)
+	checkFarLogs(nodeName, expectedLog)
 
 	By("Getting new node's boot time")
 	wasNodeRebooted(nodeName, nodeBootTimeBefore)


### PR DESCRIPTION
`checkFarLogs` was used to verify whether FAR pod had a success response from FA command.

- When we are running more than one remediation then `checkFarLogs` function could have find the success message of the first CR since we have searched for the response without any CR identification (see [old discussion](https://github.com/medik8s/fence-agents-remediation/pull/55#discussion_r1223232556)). Now we are using the node name to verify that (since we won't remediate a node more than once).

- When the FAR pod resides in the unhealthy node, then it will be evicted and one FA command is run only once (after #69), then when it will be run again on a new node it won't try to execute the FA command. Therefore, for this scenario we are skipping the check of checkFarLogs function.