### PR TITLE
Support Operator Upgrades

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -48,6 +48,7 @@ metadata:
     createdAt: ""
     description: Fence Agents Remediation Operator for remediating nodes using upstream
       fence-agents.
+    olm.skipRange: '>=0.0.1'
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/fence-agents-remediation

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     createdAt: ""
     description: Fence Agents Remediation Operator for remediating nodes using upstream
       fence-agents.
+    olm.skipRange: '>=0.0.1'
     repository: https://github.com/medik8s/fence-agents-remediation
     support: Medik8s
   name: fence-agents-remediation.v0.0.0


### PR DESCRIPTION
Adding olm.skiprange will enable FAR to be upgradeable.

For more on SkipRange see https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange