### PR TITLE
Match Condition Message to Variable Name

### DIFF
--- a/api/v1alpha1/fenceagentsremediation_types.go
+++ b/api/v1alpha1/fenceagentsremediation_types.go
@@ -31,8 +31,8 @@ const (
 	// FenceAgentActionSucceededType is the condition type used to signal whether the Fence Agent action was succeeded successfully or not
 	FenceAgentActionSucceededType = "FenceAgentActionSucceeded"
 	// condition messages
-	RemediationFinishedNodeNotFoundConditionMessage = "Node Healthcheck timeout annotation has been set"
-	RemediationInterruptedByNHCConditionMessage     = "FAR CR name doesn't match a node name"
+	RemediationFinishedNodeNotFoundConditionMessage = "FAR CR name doesn't match a node name"
+	RemediationInterruptedByNHCConditionMessage     = "Node Healthcheck timeout annotation has been set"
 	RemediationStartedConditionMessage              = "FAR CR was found, its name matches one of the cluster nodes, and a finalizer was set to the CR"
 	FenceAgentSucceededConditionMessage             = "FAR taint was added, fence agent command has been created and executed successfully"
 	RemediationFinishedSuccessfullyConditionMessage = "The unhealthy node was fully remediated (it was tainted, fenced using FA and all the node resources have been deleted)"


### PR DESCRIPTION
Condition message didn't match the variable name.
Correct condition message between Node not found and NHC time out scenarios