### PR TITLE
Explicitly Check the Return Error

### DIFF
--- a/pkg/utils/pods.go
+++ b/pkg/utils/pods.go
@@ -16,7 +16,10 @@ import (
 func GetFenceAgentsRemediationPod(r client.Reader) (*corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	selector := labels.NewSelector()
-	requirement, _ := labels.NewRequirement("app.kubernetes.io/name", selection.Equals, []string{"fence-agents-remediation-operator"})
+	requirement, err := labels.NewRequirement("app.kubernetes.io/name", selection.Equals, []string{"fence-agents-remediation-operator"})
+	if err != nil {
+		return nil, fmt.Errorf("failed creating FAR label - %w", err)
+	}
 	selector = selector.Add(*requirement)
 	podNamespace, err := GetDeploymentNamespace()
 	if err != nil {


### PR DESCRIPTION
The function returned error was ignored. We should verify if there is an error prior to proceeding with the function `GetFenceAgentsRemediationPod`.
