### PR TITLE
Add fence-azure-arm agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=builder /workspace/manager .
 # Add Fence Agents and fence-agents-aws packages
 RUN dnf install -y dnf-plugins-core \
     && dnf config-manager --set-enabled ha \
-    && dnf install -y fence-agents-all fence-agents-aws \
+    && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm \
     && dnf clean all -y
 
 USER 65532:65532


### PR DESCRIPTION
Currently, if the agent fence_azure_arm is used, FAR throws an error showing that the `fence_azure_arm` is not found. It adds the Azure fence agent.

Fix: https://github.com/medik8s/fence-agents-remediation/issues/90