### PR TITLE
Enable out-of-service taint in FAR

### DIFF
--- a/api/v1alpha1/fenceagentsremediation_types.go
+++ b/api/v1alpha1/fenceagentsremediation_types.go
@@ -44,10 +44,14 @@ const (
 	FenceAgentSucceeded ConditionsChangeReason = "FenceAgentSucceeded"
 	// RemediationFinishedSuccessfully - The unhealthy node was fully remediated/fenced (it was tainted, fenced by FA and all of its resources have been deleted)
 	RemediationFinishedSuccessfully ConditionsChangeReason = "RemediationFinishedSuccessfully"
+
+	ResourceDeletionRemediationStrategy  = RemediationStrategyType("ResourceDeletion")
+	OutOfServiceTaintRemediationStrategy = RemediationStrategyType("OutOfServiceTaint")
 )
 
 type ParameterName string
 type NodeName string
+type RemediationStrategyType string
 
 // FenceAgentsRemediationSpec defines the desired state of FenceAgentsRemediation
 type FenceAgentsRemediationSpec struct {
@@ -84,6 +88,15 @@ type FenceAgentsRemediationSpec struct {
 	// NodeParameters are passed to the fencing agent according to the node that is fenced, since they are node specific
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	NodeParameters map[ParameterName]map[NodeName]string `json:"nodeparameters,omitempty"`
+
+	// RemediationStrategy is the remediation method for unhealthy nodes.
+	// Currently, it could be either "OutOfServiceTaint" or "ResourceDeletion".
+	// ResourceDeletion will iterate over all pods related to the unhealthy node and delete them.
+	// OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+	// that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+	// +kubebuilder:default:="ResourceDeletion"
+	// +kubebuilder:validation:Enum=ResourceDeletion;OutOfServiceTaint
+	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 
 // FenceAgentsRemediationStatus defines the observed state of FenceAgentsRemediation

--- a/api/v1alpha1/fenceagentsremediation_webhook.go
+++ b/api/v1alpha1/fenceagentsremediation_webhook.go
@@ -53,19 +53,26 @@ var _ webhook.Validator = &FenceAgentsRemediation{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (far *FenceAgentsRemediation) ValidateCreate() (admission.Warnings, error) {
 	webhookFARLog.Info("validate create", "name", far.Name)
-	return validateAgentName(far.Spec.Agent)
+	return validateFAR(&far.Spec)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (far *FenceAgentsRemediation) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	webhookFARLog.Info("validate update", "name", far.Name)
-	return validateAgentName(far.Spec.Agent)
+	return validateFAR(&far.Spec)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (far *FenceAgentsRemediation) ValidateDelete() (admission.Warnings, error) {
 	webhookFARLog.Info("validate delete", "name", far.Name)
 	return nil, nil
+}
+
+func validateFAR(farSpec *FenceAgentsRemediationSpec) (admission.Warnings, error) {
+	if _, err := validateAgentName(farSpec.Agent); err != nil {
+		return nil, err
+	}
+	return validateStrategy(farSpec.RemediationStrategy)
 }
 
 func validateAgentName(agent string) (admission.Warnings, error) {
@@ -75,6 +82,13 @@ func validateAgentName(agent string) (admission.Warnings, error) {
 	}
 	if !exists {
 		return nil, fmt.Errorf("unsupported fence agent: %s", agent)
+	}
+	return nil, nil
+}
+
+func validateStrategy(farRemStrategy RemediationStrategyType) (admission.Warnings, error) {
+	if farRemStrategy == OutOfServiceTaintRemediationStrategy && !validation.IsOutOfServiceTaintSupported {
+		return nil, fmt.Errorf("%s remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy", OutOfServiceTaintRemediationStrategy)
 	}
 	return nil, nil
 }

--- a/api/v1alpha1/fenceagentsremediation_webhook_test.go
+++ b/api/v1alpha1/fenceagentsremediation_webhook_test.go
@@ -5,8 +5,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/medik8s/fence-agents-remediation/pkg/validation"
 )
 
 var _ = Describe("FenceAgentsRemediation Validation", func() {
@@ -31,14 +29,14 @@ var _ = Describe("FenceAgentsRemediation Validation", func() {
 			var outOfServiceStrategy *FenceAgentsRemediation
 
 			BeforeEach(func() {
-				orgValue := validation.IsOutOfServiceTaintSupported
-				DeferCleanup(func() { validation.IsOutOfServiceTaintSupported = orgValue })
+				orgValue := isOutOfServiceTaintSupported
+				DeferCleanup(func() { isOutOfServiceTaintSupported = orgValue })
 
 				outOfServiceStrategy = getFAR(validAgentName, OutOfServiceTaintRemediationStrategy)
 			})
 			When("out of service taint is supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = true
+					isOutOfServiceTaintSupported = true
 				})
 				It("should be allowed", func() {
 					Expect(outOfServiceStrategy.ValidateCreate()).Error().NotTo(HaveOccurred())
@@ -46,7 +44,7 @@ var _ = Describe("FenceAgentsRemediation Validation", func() {
 			})
 			When("out of service taint is not supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = false
+					isOutOfServiceTaintSupported = false
 				})
 				It("should be denied", func() {
 					Expect(outOfServiceStrategy.ValidateCreate()).Error().To(MatchError(ContainSubstring(outOfServiceTaintUnsupportedMsg)))
@@ -82,15 +80,15 @@ var _ = Describe("FenceAgentsRemediation Validation", func() {
 			var resourceDeletionStrategy *FenceAgentsRemediation
 
 			BeforeEach(func() {
-				orgValue := validation.IsOutOfServiceTaintSupported
-				DeferCleanup(func() { validation.IsOutOfServiceTaintSupported = orgValue })
+				orgValue := isOutOfServiceTaintSupported
+				DeferCleanup(func() { isOutOfServiceTaintSupported = orgValue })
 
 				outOfServiceStrategy = getFAR(validAgentName, OutOfServiceTaintRemediationStrategy)
 				resourceDeletionStrategy = getFAR(validAgentName, ResourceDeletionRemediationStrategy)
 			})
 			When("out of service taint is supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = true
+					isOutOfServiceTaintSupported = true
 				})
 				It("should be allowed", func() {
 					Expect(outOfServiceStrategy.ValidateUpdate(resourceDeletionStrategy)).Error().NotTo(HaveOccurred())
@@ -98,7 +96,7 @@ var _ = Describe("FenceAgentsRemediation Validation", func() {
 			})
 			When("out of service taint is not supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = false
+					isOutOfServiceTaintSupported = false
 				})
 				It("should be denied", func() {
 					Expect(outOfServiceStrategy.ValidateUpdate(resourceDeletionStrategy)).Error().To(MatchError(ContainSubstring(outOfServiceTaintUnsupportedMsg)))

--- a/api/v1alpha1/fenceagentsremediationtemplate_webhook.go
+++ b/api/v1alpha1/fenceagentsremediationtemplate_webhook.go
@@ -62,13 +62,13 @@ var _ webhook.Validator = &FenceAgentsRemediationTemplate{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (farTemplate *FenceAgentsRemediationTemplate) ValidateCreate() (admission.Warnings, error) {
 	webhookFARTemplateLog.Info("validate create", "name", farTemplate.Name)
-	return validateAgentName(farTemplate.Spec.Template.Spec.Agent)
+	return validateFAR(&farTemplate.Spec.Template.Spec)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (farTemplate *FenceAgentsRemediationTemplate) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	webhookFARTemplateLog.Info("validate update", "name", farTemplate.Name)
-	return validateAgentName(farTemplate.Spec.Template.Spec.Agent)
+	return validateFAR(&farTemplate.Spec.Template.Spec)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
+++ b/api/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
@@ -5,8 +5,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/medik8s/fence-agents-remediation/pkg/validation"
 )
 
 var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
@@ -31,15 +29,15 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 			var outOfServiceStrategy *FenceAgentsRemediationTemplate
 
 			BeforeEach(func() {
-				orgValue := validation.IsOutOfServiceTaintSupported
-				DeferCleanup(func() { validation.IsOutOfServiceTaintSupported = orgValue })
+				orgValue := isOutOfServiceTaintSupported
+				DeferCleanup(func() { isOutOfServiceTaintSupported = orgValue })
 
 				outOfServiceStrategy = getFARTemplate(validAgentName, OutOfServiceTaintRemediationStrategy)
 			})
 
 			When("out of service taint is supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = true
+					isOutOfServiceTaintSupported = true
 				})
 				It("should be allowed", func() {
 					Expect(outOfServiceStrategy.ValidateCreate()).Error().NotTo(HaveOccurred())
@@ -48,7 +46,7 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 
 			When("out of service taint is not supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = false
+					isOutOfServiceTaintSupported = false
 				})
 				It("should be denied", func() {
 					Expect(outOfServiceStrategy.ValidateCreate()).Error().To(MatchError(ContainSubstring(outOfServiceTaintUnsupportedMsg)))
@@ -84,8 +82,8 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 			var resourceDeletionStrategy *FenceAgentsRemediationTemplate
 
 			BeforeEach(func() {
-				orgValue := validation.IsOutOfServiceTaintSupported
-				DeferCleanup(func() { validation.IsOutOfServiceTaintSupported = orgValue })
+				orgValue := isOutOfServiceTaintSupported
+				DeferCleanup(func() { isOutOfServiceTaintSupported = orgValue })
 
 				outOfServiceStrategy = getFARTemplate(validAgentName, OutOfServiceTaintRemediationStrategy)
 				resourceDeletionStrategy = getFARTemplate(validAgentName, ResourceDeletionRemediationStrategy)
@@ -93,7 +91,7 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 
 			When("out of service taint is supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = true
+					isOutOfServiceTaintSupported = true
 				})
 				It("should be allowed", func() {
 					Expect(outOfServiceStrategy.ValidateUpdate(resourceDeletionStrategy)).Error().NotTo(HaveOccurred())
@@ -102,7 +100,7 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 
 			When("out of service taint is not supported", func() {
 				BeforeEach(func() {
-					validation.IsOutOfServiceTaintSupported = false
+					isOutOfServiceTaintSupported = false
 				})
 				It("should be denied", func() {
 					Expect(outOfServiceStrategy.ValidateUpdate(resourceDeletionStrategy)).Error().To(MatchError(ContainSubstring(outOfServiceTaintUnsupportedMsg)))

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -48,8 +48,9 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 const (
-	validAgentName   = "fence_ipmilan"
-	invalidAgentName = "fence_ip"
+	validAgentName                  = "fence_ipmilan"
+	invalidAgentName                = "fence_ip"
+	outOfServiceTaintUnsupportedMsg = "OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy"
 )
 
 var (

--- a/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
+++ b/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
@@ -58,6 +58,18 @@ spec:
                 description: NodeParameters are passed to the fencing agent according
                   to the node that is fenced, since they are node specific
                 type: object
+              remediationStrategy:
+                default: ResourceDeletion
+                description: |-
+                  RemediationStrategy is the remediation method for unhealthy nodes.
+                  Currently, it could be either "OutOfServiceTaint" or "ResourceDeletion".
+                  ResourceDeletion will iterate over all pods related to the unhealthy node and delete them.
+                  OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                  that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+                enum:
+                - ResourceDeletion
+                - OutOfServiceTaint
+                type: string
               retrycount:
                 default: 5
                 description: RetryCount is the number of times the fencing agent will

--- a/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
+++ b/bundle/manifests/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
@@ -67,6 +67,18 @@ spec:
                           according to the node that is fenced, since they are node
                           specific
                         type: object
+                      remediationStrategy:
+                        default: ResourceDeletion
+                        description: |-
+                          RemediationStrategy is the remediation method for unhealthy nodes.
+                          Currently, it could be either "OutOfServiceTaint" or "ResourceDeletion".
+                          ResourceDeletion will iterate over all pods related to the unhealthy node and delete them.
+                          OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                          that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+                        enum:
+                        - ResourceDeletion
+                        - OutOfServiceTaint
+                        type: string
                       retrycount:
                         default: 5
                         description: RetryCount is the number of times the fencing

--- a/config/crd/bases/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
+++ b/config/crd/bases/fence-agents-remediation.medik8s.io_fenceagentsremediations.yaml
@@ -56,6 +56,18 @@ spec:
                 description: NodeParameters are passed to the fencing agent according
                   to the node that is fenced, since they are node specific
                 type: object
+              remediationStrategy:
+                default: ResourceDeletion
+                description: |-
+                  RemediationStrategy is the remediation method for unhealthy nodes.
+                  Currently, it could be either "OutOfServiceTaint" or "ResourceDeletion".
+                  ResourceDeletion will iterate over all pods related to the unhealthy node and delete them.
+                  OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                  that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+                enum:
+                - ResourceDeletion
+                - OutOfServiceTaint
+                type: string
               retrycount:
                 default: 5
                 description: RetryCount is the number of times the fencing agent will

--- a/config/crd/bases/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
+++ b/config/crd/bases/fence-agents-remediation.medik8s.io_fenceagentsremediationtemplates.yaml
@@ -65,6 +65,18 @@ spec:
                           according to the node that is fenced, since they are node
                           specific
                         type: object
+                      remediationStrategy:
+                        default: ResourceDeletion
+                        description: |-
+                          RemediationStrategy is the remediation method for unhealthy nodes.
+                          Currently, it could be either "OutOfServiceTaint" or "ResourceDeletion".
+                          ResourceDeletion will iterate over all pods related to the unhealthy node and delete them.
+                          OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                          that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+                        enum:
+                        - ResourceDeletion
+                        - OutOfServiceTaint
+                        type: string
                       retrycount:
                         default: 5
                         description: RetryCount is the number of times the fencing

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 
 	//+kubebuilder:scaffold:imports
 	"github.com/medik8s/fence-agents-remediation/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/pkg/validation"
 	"github.com/medik8s/fence-agents-remediation/version"
 )
 
@@ -103,6 +104,10 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if err := validation.InitOutOfServiceTaintSupportedFlag(mgr.GetConfig()); err != nil {
+		setupLog.Error(err, "unable to verify Kubernetes version for indicating the out-of-service taint support. out-of-service taint isn't supported")
 	}
 
 	executer, err := cli.NewExecuter(mgr.GetClient(), mgr.GetEventRecorderFor(operatorName+"-executer"))

--- a/main.go
+++ b/main.go
@@ -106,9 +106,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := validation.InitOutOfServiceTaintSupportedFlag(mgr.GetConfig()); err != nil {
+	outOfServiceTaintValidator, err := validation.NewOutOfServiceTaintValidator(mgr.GetConfig())
+	if err != nil {
 		setupLog.Error(err, "unable to verify Kubernetes version for indicating the out-of-service taint support. out-of-service taint isn't supported")
 	}
+	isOutOfServiceTaintSupported := outOfServiceTaintValidator.IsOutOfServiceTaintSupported()
+	if isOutOfServiceTaintSupported {
+		setupLog.Info("out-of-service taint is supported on this cluster")
+	}
+	fenceagentsremediationv1alpha1.InitOutOfServiceTaintSupportedFlag(isOutOfServiceTaintSupported)
 
 	executer, err := cli.NewExecuter(mgr.GetClient(), mgr.GetEventRecorderFor(operatorName+"-executer"))
 	if err != nil {

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -15,6 +15,8 @@ const (
 	EventReasonFenceAgentExecuted       = "FenceAgentExecuted"
 	EventReasonFenceAgentSucceeded      = "FenceAgentSucceeded"
 	EventReasonDeleteResources          = "DeleteResources"
+	EventReasonAddOutOfServiceTaint     = "AddOutOfServiceTaint"
+	EventReasonRemoveOutOfServiceTaint  = "RemoveOutOfServiceTaint"
 	EventReasonNodeRemediationCompleted = "NodeRemediationCompleted"
 
 	// events messages
@@ -27,5 +29,7 @@ const (
 	EventMessageFenceAgentExecuted       = "Fence agent was executed"
 	EventMessageFenceAgentSucceeded      = "Fence agent was succeeded"
 	EventMessageDeleteResources          = "Manually delete pods from the unhealthy node"
+	EventMessageAddOutOfServiceTaint     = "The out-of-service taint was added"
+	EventMessageRemoveOutOfServiceTaint  = "The out-of-service taint was removed"
 	EventMessageNodeRemediationCompleted = "Unhealthy node remediation was completed"
 )

--- a/pkg/utils/taint_test.go
+++ b/pkg/utils/taint_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Utils-taint", func() {
 				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
 				// control-plane-role taint already exist by GetNode
 				By("adding medik8s NoSchedule taint")
-				Expect(AppendTaint(k8sClient, node0)).Error().NotTo(HaveOccurred())
+				Expect(AppendTaint(k8sClient, node0, CreateRemediationTaint())).Error().NotTo(HaveOccurred())
 				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
 				Expect(TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
 				Expect(TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeTrue())

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -51,16 +51,24 @@ func CreateRemediationTaint() corev1.Taint {
 	}
 }
 
+// CreateOutOfServiceTaint returns an OutOfService taint
+func CreateOutOfServiceTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    corev1.TaintNodeOutOfService,
+		Value:  "nodeshutdown",
+		Effect: corev1.TaintEffectNoExecute,
+	}
+}
+
 // AppendTaint appends new taint to the taint list when it is not present.
 // It returns bool if a taint was appended, and an error if it fails in the process
-func AppendTaint(r client.Client, nodeName string) (bool, error) {
+func AppendTaint(r client.Client, nodeName string, taint corev1.Taint) (bool, error) {
 	// find node by name
 	node, err := GetNodeWithName(r, nodeName)
 	if node == nil {
 		return false, err
 	}
 
-	taint := CreateRemediationTaint()
 	// check if taint doesn't exist
 	if TaintExists(node.Spec.Taints, &taint) {
 		return false, nil

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -4,6 +4,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	loggerValidation = ctrl.Log.WithName("validation")
+	//IsOutOfServiceTaintSupported will be set to true in case OutOfServiceTaint is supported (k8s 1.26 or higher)
+	IsOutOfServiceTaintSupported bool
+	leadingDigits                = regexp.MustCompile(`^(\d+)`)
+)
+
+const (
+	//out of service taint strategy const (supported from 1.26)
+	minK8sMajorVersionOutOfServiceTaint = 1
+	minK8sMinorVersionOutOfServiceTaint = 26
 )
 
 type AgentExists func(string) (bool, error)
@@ -42,4 +62,41 @@ func NewCustomAgentValidator(agentExists AgentExists) AgentValidator {
 
 func (vfe *validateAgentExistence) ValidateAgentName(agent string) (bool, error) {
 	return vfe.agentExists(agent)
+}
+
+// InitOutOfServiceTaintSupportedFlag checks a cluster's k8s version and
+// set the IsOutOfServiceTaintSupported flag to true if out-of-service is supported on the cluster
+func InitOutOfServiceTaintSupportedFlag(config *rest.Config) error {
+	if cs, err := kubernetes.NewForConfig(config); err != nil || cs == nil {
+		if cs == nil {
+			err = fmt.Errorf("k8s client set is nil")
+		}
+		loggerValidation.Error(err, "couldn't retrieve k8s client")
+		return err
+	} else if k8sVersion, err := cs.Discovery().ServerVersion(); err != nil || k8sVersion == nil {
+		if k8sVersion == nil {
+			err = fmt.Errorf("k8s server version is nil")
+		}
+		loggerValidation.Error(err, "couldn't retrieve k8s server version")
+		return err
+	} else {
+		return setOutOfTaintSupportedFlag(k8sVersion)
+	}
+}
+
+func setOutOfTaintSupportedFlag(version *version.Info) error {
+	var majorVer, minorVer int
+	var err error
+	if majorVer, err = strconv.Atoi(version.Major); err != nil {
+		loggerValidation.Error(err, "couldn't parse k8s major version", "major version", version.Major)
+		return err
+	}
+	if minorVer, err = strconv.Atoi(leadingDigits.FindString(version.Minor)); err != nil {
+		loggerValidation.Error(err, "couldn't parse k8s minor version", "minor version", version.Minor)
+		return err
+	}
+
+	IsOutOfServiceTaintSupported = majorVer > minK8sMajorVersionOutOfServiceTaint || (majorVer == minK8sMajorVersionOutOfServiceTaint && minorVer >= minK8sMinorVersionOutOfServiceTaint)
+	loggerValidation.Info("out of service taint strategy", "isSupported", IsOutOfServiceTaintSupported, "k8sMajorVersion", majorVer, "k8sMinorVersion", minorVer)
+	return nil
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+func Test_setOutOfTaintSupportedFlag(t *testing.T) {
+	type args struct {
+		version *version.Info
+	}
+	tests := []struct {
+		name                    string
+		args                    args
+		wantErr                 bool
+		isOutOfTaintFlagEnabled bool
+	}{
+		//valid use-cases
+		{name: "validEnabledNoPlus", args: args{&version.Info{Major: "1", Minor: "26"}}, wantErr: false, isOutOfTaintFlagEnabled: true},
+		{name: "validDisabledEnabledNoPlus", args: args{&version.Info{Major: "1", Minor: "24"}}, wantErr: false, isOutOfTaintFlagEnabled: false},
+		{name: "validEnabledWithPlus", args: args{&version.Info{Major: "1", Minor: "26+"}}, wantErr: false, isOutOfTaintFlagEnabled: true},
+		{name: "validDisabledWithPlus", args: args{&version.Info{Major: "1", Minor: "24+"}}, wantErr: false, isOutOfTaintFlagEnabled: false},
+		{name: "validEnabledWithTrailingChars", args: args{&version.Info{Major: "1", Minor: "26.5.2#$%+"}}, wantErr: false, isOutOfTaintFlagEnabled: true},
+		{name: "validDisabledWithTrailingChars", args: args{&version.Info{Major: "1", Minor: "22.5.2#$%+"}}, wantErr: false, isOutOfTaintFlagEnabled: false},
+
+		//invalid use-cases
+		{name: "inValidNoPlus", args: args{&version.Info{Major: "1", Minor: "%24"}}, wantErr: true, isOutOfTaintFlagEnabled: false},
+		{name: "inValidWithPlus", args: args{&version.Info{Major: "1+", Minor: "26"}}, wantErr: true, isOutOfTaintFlagEnabled: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			IsOutOfServiceTaintSupported = false
+			if err := setOutOfTaintSupportedFlag(tt.args.version); (err != nil) != tt.wantErr || IsOutOfServiceTaintSupported != tt.isOutOfTaintFlagEnabled {
+				t.Errorf("setOutOfTaintFlags() error = %v, wantErr %v, expected out of taint flag %v", err, tt.wantErr, tt.isOutOfTaintFlagEnabled)
+			}
+		})
+	}
+}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -30,8 +30,8 @@ func Test_setOutOfTaintSupportedFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			IsOutOfServiceTaintSupported = false
-			if err := setOutOfTaintSupportedFlag(tt.args.version); (err != nil) != tt.wantErr || IsOutOfServiceTaintSupported != tt.isOutOfTaintFlagEnabled {
+			v := &OutOfServiceTaintValidator{}
+			if err := v.setOutOfServiceTaintSupportedFlag(tt.args.version); (err != nil) != tt.wantErr || v.IsOutOfServiceTaintSupported() != tt.isOutOfTaintFlagEnabled {
 				t.Errorf("setOutOfTaintFlags() error = %v, wantErr %v, expected out of taint flag %v", err, tt.wantErr, tt.isOutOfTaintFlagEnabled)
 			}
 		})

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"math/rand"
+	"os"
 	"time"
 
 	commonConditions "github.com/medik8s/common/pkg/conditions"
@@ -44,6 +45,7 @@ const (
 	pollTaint          = "100ms"
 	pollReboot         = "1s"
 	pollAfterReboot    = "250ms"
+	skipOOSREnvVarName = "SKIP_OOST_REMEDIATION_VERIFICATION"
 )
 
 var remediationTimes []time.Duration
@@ -124,6 +126,10 @@ var _ = Describe("FAR E2e", func() {
 	Context("stress cluster with OutOfServiceTaint remediation strategy", func() {
 		var availableWorkerNodes *corev1.NodeList
 		BeforeEach(func() {
+			if _, isExist := os.LookupEnv(skipOOSREnvVarName); isExist {
+				Skip("Skip this block due to out-of-service taint not supported")
+			}
+
 			if availableWorkerNodes == nil {
 				availableWorkerNodes = getAvailableWorkerNodes()
 			}

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -196,6 +196,11 @@ func GetPod(nodeName, containerName string) *corev1.Pod {
 					Operator: corev1.TolerationOpEqual,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
+				{
+					Key:      corev1.TaintNodeOutOfService,
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoExecute,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR is adding a new remediation strategy based on https://github.com/kubernetes/enhancements/pull/1116

The following is the new remediation strategy for the out-of-service taint:
1. One of the nodes failed
2. FAR adds NoExecute taint to the failed node
=> Ensure that any workloads are not executed after rebooting the failed node
3. FAR reboots the failed node via the Fence Agent
=>  After rebooting, there are no stateless workloads which were not evicted by the taint in the failed node
4. FAR sets the out-of-service taint
=> This taint expects that the node is in shutdown or power off state (not in the middle of restarting).
5. After the failed node becomes healthy, the NoExecute taint in Step 2 and the out-of-service taint in Step 5 are removed and the node becomes schedulable again.

[ToDo]
- [x] Add unit tests
- [x] Add comments to clarify the changes of this patch
- [x] Add e2e test cases
- [x] Add a validation test of the Kubernetes version (https://github.com/medik8s/self-node-remediation/pull/104)

[ECOPROJECT-1326](https://issues.redhat.com/browse/ECOPROJECT-1326)