### PR TITLE
[WIP] Create far or far template CR Examples on OCP and Cloud Agents

### DIFF
--- a/hack/example_creation/create_cr_example.sh
+++ b/hack/example_creation/create_cr_example.sh
@@ -1,40 +1,60 @@
 #!/bin/bash
-# The below script is meant for creating FenceAgentsRemediation/FenceAgentsRemediationTemplate CR for
-#  the following platforms: AWS, BareMetal, Azure, and GCP
-# Install fence-agents-azure-arm, and fence-agents-gce packages for Azure and GCP fence agents respectively
 # set -ex
 
-# Source the functions from get_parameters.sh
-source ./hack/example_creation/get_parameters.sh
+# The below script is meant for creating FenceAgentsRemediation/FenceAgentsRemediationTemplate CR for
+# the following platforms: AWS, Azure, BareMetal, and GCP
+# 1. AWS - https://www.mankier.com/8/fence_aws
+# 2. Azure - https://www.mankier.com/8/fence_azure_arm
+# 3. BareMetal - https://www.mankier.com/8/fence_ipmilan
+# 4. GCP - https://www.mankier.com/8/fence_gce
+# Install fence-agents-azure-arm, and fence-agents-gce packages for Azure and GCP fence agents respectively
 
-OPERATOR_NS=$2 #"openshift-operators"
+# Input validation
+if [ $# -eq 2 ]; then
+  CR_KIND=$1
+  OPERATOR_NS=$2
+elif [ $# -eq 1 ]; then
+  CR_KIND=$1
+  echo "CR namespace is by default openshift-operators"
+  OPERATOR_NS="openshift-operators" 
+else
+  echo "Usage: $0: expecing at most two variables - CR_KIND and Namespace"
+  exit 1
+fi
+
 MACHINE_NAMESPACE="openshift-machine-api"
-# For template CR we add spaces and spec.template.spec
-CR_TEMPLATE_TYPE="FenceAgentsRemediationTemplate"
 # Get the node names from the Kubernetes API
 nodes=$(oc get machines -o json -n ${MACHINE_NAMESPACE} | jq -r '.items[].status.nodeRef.name')
 # Create an array by splitting the multiline string on line breaks
 IFS=$'\n' read -r -d '' -a array_nodes <<< "${nodes}"
 
+# Source the functions from get_parameters.sh
+source ./hack/example_creation/get_parameters.sh
+
 # Find platform
 platform=$(oc get Infrastructure.config.openshift.io/cluster -o jsonpath='{.spec.platformSpec.type}')
-example_cr_name=$(get_examples_name $1 "${platform}")
+example_cr_name=$(get_examples_name ${CR_KIND} "${platform}")
 read -r EXAMPLE_NAME CR_NAME <<< "${example_cr_name}"
-echo "The script is creating a CR example of kind $1 with at '${EXAMPLE_NAME}'"
+# We exit on error
+[[ ${CR_NAME} == "error" ]] && echo "Error ${EXAMPLE_NAME}" && exit 1 
+echo "The script is creating a CR example of kind ${CR_KIND} with at '${EXAMPLE_NAME}'"
 
-# When it is not a remediation template we select the fourth node name to remediate (should be a worker node in case there are only three control-plane nodes)
-[[ $1 != ${CR_TEMPLATE_TYPE} ]] && CR_NAME=${array_nodes[3]}
+# For template CR we add spaces and spec.template.spec
+CR_TEMPLATE_TYPE="FenceAgentsRemediationTemplate"
+# When it is not a remediation template we select the fourth node name to remediate 
+# (it should be a worker node in case there are only three control-plane nodes)
+[[ ${CR_KIND} != ${CR_TEMPLATE_TYPE} ]] && CR_NAME=${array_nodes[3]}
 
-# Generate the FenceAgentsRemediationTemplate CR manifest metadata
+# Generate the CR manifest metadata
 cat <<EOF > "${EXAMPLE_NAME}"
 apiVersion: fence-agents-remediation.medik8s.io/v1alpha1
-kind: $1
+kind: ${CR_KIND}
 metadata:
   name: ${CR_NAME}
   namespace: ${OPERATOR_NS}
 spec:
 EOF
-[[ $1 == ${CR_TEMPLATE_TYPE} ]] && cat <<EOF >> "${EXAMPLE_NAME}"
+[[ ${CR_KIND} == ${CR_TEMPLATE_TYPE} ]] && cat <<EOF >> "${EXAMPLE_NAME}"
   template:
     spec:
 EOF
@@ -42,7 +62,7 @@ EOF
 nodeparameters=($(get_nodeparameters "${platform}"))
 sharedparameters=$(get_sharedparameters "${platform}")
 
-# Generate the FenceAgentsRemediation CR manifest spec
+# Generate the CR manifest spec
 case "${platform}" in
   "AWS")
     cat <<EOF >> "${EXAMPLE_NAME}"
@@ -63,28 +83,7 @@ EOF
     '--secret-key': ${aws_key}
   agent: fence_aws
 EOF
-    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
-    ;;
-  "BareMetal")
-    # Split the sharedparameters result into individual variables
-    read -r bmh_username bmh_password <<< "${sharedparameters}"
-    cat <<EOF >> "${EXAMPLE_NAME}"
-  nodeparameters:
-    '--ipport':
-      master-0: '6230'
-      master-1: '6231'
-      master-2: '6232'
-      worker-0: '6233'
-      worker-1: '6234'
-      worker-2: '6235'
-  sharedparameters:
-    '--ip': 192.168.111.1
-    '--lanplus': ''
-    '--username': ${bmh_username}
-    '--password': ${bmh_password}
-  agent: fence_ipmilan
-EOF
-    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
+    [[ ${CR_KIND} == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
     ;;
   "Azure")
     cat <<EOF >> "${EXAMPLE_NAME}"
@@ -106,7 +105,48 @@ EOF
     '--tenantId': ${azure_tenant_id}
   agent: fence_azure_arm
 EOF
-    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,24 s/^/    /' "${EXAMPLE_NAME}"
+    [[ ${CR_KIND} == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,24 s/^/    /' "${EXAMPLE_NAME}"
+    ;;
+  "BareMetal")
+    # Split the sharedparameters result into individual variables
+    read -r bmh_username bmh_password <<< "${sharedparameters}"
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  nodeparameters:
+    '--ipport':
+      master-0: '6230'
+      master-1: '6231'
+      master-2: '6232'
+      worker-0: '6233'
+      worker-1: '6234'
+      worker-2: '6235'
+  sharedparameters:
+    '--ip': 192.168.111.1
+    '--lanplus': ''
+    '--username': ${bmh_username}
+    '--password': ${bmh_password}
+  agent: fence_ipmilan
+EOF
+    [[ ${CR_KIND} == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
+    ;;
+  "GCP")
+  cat <<EOF >> "${EXAMPLE_NAME}"
+  nodeparameters:    
+    '--plug':
+EOF
+    for i in "${!array_nodes[@]}"; do
+      echo "      ${array_nodes[${i}]}: '${array_nodes[${i}]}'" >> "${EXAMPLE_NAME}"
+    done
+    
+    # Split the sharedparameters result into individual variables
+    read -r gcp_service_account gcp_project gcp_zone <<< "${sharedparameters}"
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  sharedparameters:
+    '--serviceaccount': ${gcp_service_account}
+    '--project': ${gcp_project}
+    '--zone': ${gcp_zone}
+  agent: fence_gce
+EOF
+    [[ ${CR_KIND} == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,22 s/^/    /' "${EXAMPLE_NAME}"  
     ;;
   *)
     ;;

--- a/hack/example_creation/create_cr_example.sh
+++ b/hack/example_creation/create_cr_example.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# The below script is meant for creating FenceAgentsRemediation/FenceAgentsRemediationTemplate CR for
+#  the following platforms: AWS, BareMetal, Azure, and GCP
+# Install fence-agents-azure-arm, and fence-agents-gce packages for Azure and GCP fence agents respectively
+# set -ex
+
+# Source the functions from get_parameters.sh
+source ./hack/example_creation/get_parameters.sh
+
+OPERATOR_NS=$2 #"openshift-operators"
+MACHINE_NAMESPACE="openshift-machine-api"
+# For template CR we add spaces and spec.template.spec
+CR_TEMPLATE_TYPE="FenceAgentsRemediationTemplate"
+# Get the node names from the Kubernetes API
+nodes=$(oc get machines -o json -n ${MACHINE_NAMESPACE} | jq -r '.items[].status.nodeRef.name')
+# Create an array by splitting the multiline string on line breaks
+IFS=$'\n' read -r -d '' -a array_nodes <<< "${nodes}"
+
+# Find platform
+platform=$(oc get Infrastructure.config.openshift.io/cluster -o jsonpath='{.spec.platformSpec.type}')
+example_cr_name=$(get_examples_name $1 "${platform}")
+read -r EXAMPLE_NAME CR_NAME <<< "${example_cr_name}"
+echo "The script is creating a CR example of kind $1 with at '${EXAMPLE_NAME}'"
+
+# When it is not a remediation template we select the fourth node name to remediate (should be a worker node in case there are only three control-plane nodes)
+[[ $1 != ${CR_TEMPLATE_TYPE} ]] && CR_NAME=${array_nodes[3]}
+
+# Generate the FenceAgentsRemediationTemplate CR manifest metadata
+cat <<EOF > "${EXAMPLE_NAME}"
+apiVersion: fence-agents-remediation.medik8s.io/v1alpha1
+kind: $1
+metadata:
+  name: ${CR_NAME}
+  namespace: ${OPERATOR_NS}
+spec:
+EOF
+[[ $1 == ${CR_TEMPLATE_TYPE} ]] && cat <<EOF >> "${EXAMPLE_NAME}"
+  template:
+    spec:
+EOF
+
+nodeparameters=($(get_nodeparameters "${platform}"))
+sharedparameters=$(get_sharedparameters "${platform}")
+
+# Generate the FenceAgentsRemediation CR manifest spec
+case "${platform}" in
+  "AWS")
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  nodeparameters:    
+    '--plug':
+EOF
+    for i in "${!nodeparameters[@]}"; do
+      echo "      ${array_nodes[${i}]}: '${nodeparameters[${i}]}'" >> "${EXAMPLE_NAME}"
+    done
+    
+    # Split the sharedparameters result into individual variables
+    read -r aws_key_id aws_key aws_region <<< "${sharedparameters}"
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  sharedparameters:
+    '--region': ${aws_region}
+    '--skip-race-check': ''
+    '--access-key': ${aws_key_id}
+    '--secret-key': ${aws_key}
+  agent: fence_aws
+EOF
+    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
+    ;;
+  "BareMetal")
+    # Split the sharedparameters result into individual variables
+    read -r bmh_username bmh_password <<< "${sharedparameters}"
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  nodeparameters:
+    '--ipport':
+      master-0: '6230'
+      master-1: '6231'
+      master-2: '6232'
+      worker-0: '6233'
+      worker-1: '6234'
+      worker-2: '6235'
+  sharedparameters:
+    '--ip': 192.168.111.1
+    '--lanplus': ''
+    '--username': ${bmh_username}
+    '--password': ${bmh_password}
+  agent: fence_ipmilan
+EOF
+    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,23 s/^/    /' "${EXAMPLE_NAME}"  
+    ;;
+  "Azure")
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  nodeparameters:
+    '--plug':
+EOF
+    for i in "${!array_nodes[@]}"; do
+      echo "      ${array_nodes[${i}]}: '${array_nodes[${i}]}'" >> "${EXAMPLE_NAME}"
+    done
+
+    # Split the sharedparameters result into individual variables
+    read -r azure_username azure_password azure_resource_group azure_subscription_id azure_tenant_id <<< "${sharedparameters}"
+    cat <<EOF >> "${EXAMPLE_NAME}"
+  sharedparameters:
+    '--username': ${azure_username}
+    '--password': ${azure_password}
+    '--resourceGroup': ${azure_resource_group}
+    '--subscriptionId': ${azure_subscription_id}
+    '--tenantId': ${azure_tenant_id}
+  agent: fence_azure_arm
+EOF
+    [[ $1 == ${CR_TEMPLATE_TYPE} ]] && sed -i '9,24 s/^/    /' "${EXAMPLE_NAME}"
+    ;;
+  *)
+    ;;
+esac
+
+machine=$(oc get machines -o=custom-columns=node:.status.nodeRef.name,machine:.metadata.name,ProviderID:.spec.providerID -n "${MACHINE_NAMESPACE}")
+echo "${machine}"

--- a/hack/example_creation/get_parameters.sh
+++ b/hack/example_creation/get_parameters.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# set -ex
+MACHINE_NAMESPACE="openshift-machine-api"
+
+function get_examples_name() {
+    SAMPLES_LOCARTION="config/samples/"
+    SUFFIX=""
+    SUFFIX_FAR_CR_TYPE="FenceAgentsRemediation"
+    SUFFIX_FAR_TEMPLATE_CR_TYPE="FenceAgentsRemediationTemplate"
+    SUFFIX_FAR_CR="_fence-agents-remediation_v1alpha1_fenceagentsremediation.yaml"
+    SUFFIX_FAR_TEMPLATE_CR="_fence-agents-remediation_v1alpha1_fenceagentsremediationtemplate.yaml"
+    # [[ $1 == ${SUFFIX_FAR_CR_TYPE} ]] && SUFFIX=${SUFFIX_FAR_CR}
+    # [[ $1 == ${SUFFIX_FAR_TEMPLATE_CR_TYPE} ]] && SUFFIX=${SUFFIX_FAR_TEMPLATE_CR}
+    if [ "$1" == ${SUFFIX_FAR_CR_TYPE} ]; then
+      SUFFIX=${SUFFIX_FAR_CR}
+    elif [ "$1" == ${SUFFIX_FAR_TEMPLATE_CR_TYPE} ]; then
+      SUFFIX=${SUFFIX_FAR_TEMPLATE_CR}
+    fi
+    case $2 in
+    "AWS")
+        # AWS - https://www.mankier.com/8/fence_aws
+        echo "${SAMPLES_LOCARTION}"aws"${SUFFIX} far-aws-template"
+        ;;
+    "BareMetal")
+        # BareMetal - https://www.mankier.com/8/fence_ipmilan
+        echo "${SAMPLES_LOCARTION}"bmh"${SUFFIX} far-bmh-template"
+        ;;
+    "Azure")
+        # Azure - https://www.mankier.com/8/fence_azure_arm
+        echo "${SAMPLES_LOCARTION}"azure"${SUFFIX} far-azure-template"
+        ;;
+    "GCP")
+        # GCP - https://www.mankier.com/8/fence_gce 
+        echo "${SAMPLES_LOCARTION}"gcp"${SUFFIX} far-gcp-template"
+        ;;
+    *)
+        echo "\nUnrecognized/unsupported platform- ${platform}\n  " 
+        ;;
+    esac
+}
+
+function get_sharedparameters(){
+  # AWS - https://www.mankier.com/8/fence_aws
+  SECRET_AWS_NAME="aws-cloud-fencing-credentials-secret"
+  SECRET_AWS_NAMESPACE="openshift-operators"
+
+  # BareMetal - https://www.mankier.com/8/fence_ipmilan
+  SECRET_BMH_NAME="ostest-master-0-bmc-secret"
+  SECRET_BMH_NAMESPACE=${MACHINE_NAMESPACE}
+
+  # Azure - https://www.mankier.com/8/fence_azure_arm
+  SECRET_AZURE_NAME="azure-cloud-credentials"
+  SECRET_AZURE_NAMESPACE=${MACHINE_NAMESPACE}
+
+  # GCP
+  SECRET_GCP_NAME="gcp-cloud-credentials"
+
+  case $1 in
+    "AWS")
+      # make ocp-aws-credentials
+      aws_key_id=$(oc get secrets -n "${SECRET_AWS_NAMESPACE}" "${SECRET_AWS_NAME}" -o jsonpath='{.data.aws_access_key_id}' | base64 -d)
+      aws_key=$(oc get secrets -n ${SECRET_AWS_NAMESPACE} ${SECRET_AWS_NAME} -o jsonpath='{.data.aws_secret_access_key}' | base64 -d)
+      aws_region=$(oc get machines -o json -n ${MACHINE_NAMESPACE} | jq -r '.items[0].spec.providerID' |  cut -d'/' -f4 | sed 's/.$//')
+      
+      echo "$aws_key_id $aws_key $aws_region"
+      echo "Platform is AWS, thus we are creating fence_aws FA and the secret is" "${SECRET_AWS_NAME}"
+      ;;
+    "BareMetal")
+      bmh_username=$(oc get secrets -n "${SECRET_BMH_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.username}' | base64 -d)
+      bmh_password=$(oc get secrets -n "${SECRET_BMH_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.password}' | base64 -d)
+
+      echo "$bmh_username $bmh_password"
+      echo "Platform is BareMetal, thus we are creating fence_ipmilan FA and the secret is" "${SECRET_BMH_NAME}"
+      ;;
+    "Azure")
+      azure_username=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_id}' | base64 -d)
+      azure_password=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_secret}' | base64 -d)
+      azure_resource_group=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_resourcegroup}' | base64 -d)
+      azure_subscription_id=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_subscription_id}' | base64 -d)
+      azure_tenant_id=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_tenant_id}' | base64 -d)
+      
+      echo "$azure_username $azure_password $azure_resource_group $azure_subscription_id $azure_tenant_id "
+      echo "Platform is Azure, thus we are creating fence_azure_arm FA and the secret is" "${SECRET_AZURE_NAME}"
+      ;;
+    "GCP")
+      # echo "Platform is GCP, thus we are creating fence_gce FA and the secret is" "${SECRET_GCP_NAME}"
+      ;;
+    *)
+      ;;
+  esac
+  }
+function get_nodeparameters(){
+  case $1 in
+    "AWS")
+      # node -> instance_id
+      # Get the instance IDs from the Kubernetes API
+      instance_ids=$(oc get machines -o json -n "${MACHINE_NAMESPACE}" | jq -r '.items[].spec.providerID' | awk -F/ '{print $NF}')
+      # Create an array by splitting the multiline string on line breaks
+      IFS=$'\n' read -r -d '' -a array_instance_ids <<< "${instance_ids}"
+      echo "${array_instance_ids[@]}"
+      ;;
+    "BareMetal")
+      # TODO: Find the ports
+      # node -> port
+      ;;
+    "Azure")
+      # node_name -> node_name
+      ;;
+    "GCP")
+      ;;
+    *)
+      ;;
+  esac
+}

--- a/hack/example_creation/get_parameters.sh
+++ b/hack/example_creation/get_parameters.sh
@@ -1,89 +1,84 @@
 #!/bin/bash
 # set -ex
 MACHINE_NAMESPACE="openshift-machine-api"
+SAMPLES_LOCARTION="config/samples/"
 
 function get_examples_name() {
-    SAMPLES_LOCARTION="config/samples/"
     SUFFIX=""
     SUFFIX_FAR_CR_TYPE="FenceAgentsRemediation"
     SUFFIX_FAR_TEMPLATE_CR_TYPE="FenceAgentsRemediationTemplate"
     SUFFIX_FAR_CR="_fence-agents-remediation_v1alpha1_fenceagentsremediation.yaml"
     SUFFIX_FAR_TEMPLATE_CR="_fence-agents-remediation_v1alpha1_fenceagentsremediationtemplate.yaml"
-    # [[ $1 == ${SUFFIX_FAR_CR_TYPE} ]] && SUFFIX=${SUFFIX_FAR_CR}
-    # [[ $1 == ${SUFFIX_FAR_TEMPLATE_CR_TYPE} ]] && SUFFIX=${SUFFIX_FAR_TEMPLATE_CR}
     if [ "$1" == ${SUFFIX_FAR_CR_TYPE} ]; then
       SUFFIX=${SUFFIX_FAR_CR}
     elif [ "$1" == ${SUFFIX_FAR_TEMPLATE_CR_TYPE} ]; then
       SUFFIX=${SUFFIX_FAR_TEMPLATE_CR}
+    else
+      echo "Unrecognized/unsupported-CR-kind error"
+      exit 1
     fi
+
     case $2 in
     "AWS")
-        # AWS - https://www.mankier.com/8/fence_aws
         echo "${SAMPLES_LOCARTION}"aws"${SUFFIX} far-aws-template"
         ;;
-    "BareMetal")
-        # BareMetal - https://www.mankier.com/8/fence_ipmilan
-        echo "${SAMPLES_LOCARTION}"bmh"${SUFFIX} far-bmh-template"
-        ;;
     "Azure")
-        # Azure - https://www.mankier.com/8/fence_azure_arm
         echo "${SAMPLES_LOCARTION}"azure"${SUFFIX} far-azure-template"
         ;;
+    "BareMetal")
+        echo "${SAMPLES_LOCARTION}"bmh"${SUFFIX} far-bmh-template"
+        ;;
     "GCP")
-        # GCP - https://www.mankier.com/8/fence_gce 
         echo "${SAMPLES_LOCARTION}"gcp"${SUFFIX} far-gcp-template"
         ;;
     *)
-        echo "\nUnrecognized/unsupported platform- ${platform}\n  " 
+        echo "Unrecognized/unsupported-platform-${platform} error" 
         ;;
     esac
 }
 
 function get_sharedparameters(){
-  # AWS - https://www.mankier.com/8/fence_aws
-  SECRET_AWS_NAME="aws-cloud-fencing-credentials-secret"
   SECRET_AWS_NAMESPACE="openshift-operators"
-
-  # BareMetal - https://www.mankier.com/8/fence_ipmilan
-  SECRET_BMH_NAME="ostest-master-0-bmc-secret"
-  SECRET_BMH_NAMESPACE=${MACHINE_NAMESPACE}
-
-  # Azure - https://www.mankier.com/8/fence_azure_arm
+  SECRET_AWS_NAME="aws-cloud-fencing-credentials-secret"
   SECRET_AZURE_NAME="azure-cloud-credentials"
-  SECRET_AZURE_NAMESPACE=${MACHINE_NAMESPACE}
-
-  # GCP
+  SECRET_BMH_NAME="ostest-master-0-bmc-secret"
   SECRET_GCP_NAME="gcp-cloud-credentials"
+  SERVICE_ACCOUNT_GCP=${SAMPLES_LOCARTION}sa_gcp.json
 
   case $1 in
     "AWS")
       # make ocp-aws-credentials
       aws_key_id=$(oc get secrets -n "${SECRET_AWS_NAMESPACE}" "${SECRET_AWS_NAME}" -o jsonpath='{.data.aws_access_key_id}' | base64 -d)
-      aws_key=$(oc get secrets -n ${SECRET_AWS_NAMESPACE} ${SECRET_AWS_NAME} -o jsonpath='{.data.aws_secret_access_key}' | base64 -d)
-      aws_region=$(oc get machines -o json -n ${MACHINE_NAMESPACE} | jq -r '.items[0].spec.providerID' |  cut -d'/' -f4 | sed 's/.$//')
+      aws_key=$(oc get secrets -n "${SECRET_AWS_NAMESPACE}" "${SECRET_AWS_NAME}" -o jsonpath='{.data.aws_secret_access_key}' | base64 -d)
+      aws_region=$(oc get machines -o json -n "${MACHINE_NAMESPACE}" | jq -r '.items[0].spec.providerID' |  cut -d'/' -f4 | sed 's/.$//')
       
       echo "$aws_key_id $aws_key $aws_region"
-      echo "Platform is AWS, thus we are creating fence_aws FA and the secret is" "${SECRET_AWS_NAME}"
-      ;;
-    "BareMetal")
-      bmh_username=$(oc get secrets -n "${SECRET_BMH_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.username}' | base64 -d)
-      bmh_password=$(oc get secrets -n "${SECRET_BMH_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.password}' | base64 -d)
-
-      echo "$bmh_username $bmh_password"
-      echo "Platform is BareMetal, thus we are creating fence_ipmilan FA and the secret is" "${SECRET_BMH_NAME}"
+      echo "Platform is AWS, thus we are creating fence_aws fence agent, and the secret name is" "${SECRET_AWS_NAME}" "at namespace" "${MACHINE_NAMESPACE}" 1>&2
       ;;
     "Azure")
-      azure_username=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_id}' | base64 -d)
-      azure_password=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_secret}' | base64 -d)
-      azure_resource_group=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_resourcegroup}' | base64 -d)
-      azure_subscription_id=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_subscription_id}' | base64 -d)
-      azure_tenant_id=$(oc get secrets -n "${SECRET_AZURE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_tenant_id}' | base64 -d)
+      azure_username=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_id}' | base64 -d)
+      azure_password=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_client_secret}' | base64 -d)
+      azure_resource_group=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_resourcegroup}' | base64 -d)
+      azure_subscription_id=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_subscription_id}' | base64 -d)
+      azure_tenant_id=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_AZURE_NAME}" -o jsonpath='{.data.azure_tenant_id}' | base64 -d)
       
-      echo "$azure_username $azure_password $azure_resource_group $azure_subscription_id $azure_tenant_id "
-      echo "Platform is Azure, thus we are creating fence_azure_arm FA and the secret is" "${SECRET_AZURE_NAME}"
+      echo "$azure_username $azure_password $azure_resource_group $azure_subscription_id $azure_tenant_id"
+      echo "Platform is Azure, thus we are creating fence_azure_arm fence agent, and the secret name is" "${SECRET_AZURE_NAME}" "at namespace" "${MACHINE_NAMESPACE}" 1>&2
+      ;;
+    "BareMetal")
+      bmh_username=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.username}' | base64 -d)
+      bmh_password=$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_BMH_NAME}" -o jsonpath='{.data.password}' | base64 -d)
+
+      echo "$bmh_username $bmh_password"
+      echo "Platform is BareMetal, thus we are creating fence_ipmilan fence agent, and the secret name is" "${SECRET_BMH_NAME}" "at namespace" "${MACHINE_NAMESPACE}" 1>&2
       ;;
     "GCP")
-      # echo "Platform is GCP, thus we are creating fence_gce FA and the secret is" "${SECRET_GCP_NAME}"
+      echo "$(oc get secrets -n "${MACHINE_NAMESPACE}" "${SECRET_GCP_NAME}" -o jsonpath='{.data.service_account\.json}' | base64 -d)" > "${SERVICE_ACCOUNT_GCP}"
+      gcp_project=$(oc get machines -o json -n "${MACHINE_NAMESPACE}" | jq -r '.items[0].spec.providerID' |  cut -d'/' -f3)
+      gcp_zone=$(oc get machines -o json -n "${MACHINE_NAMESPACE}" | jq -r '.items[3].spec.providerID' |  cut -d'/' -f4)
+      echo "$SERVICE_ACCOUNT_GCP $gcp_project $gcp_zone"
+      echo "Platform is GCP, thus we are creating fence_gce fence agent, and the secret name is" "${SECRET_GCP_NAME}" "at namespace" "${MACHINE_NAMESPACE}" 1>&2
+      echo "Attention: The GCP zone might be different per node and by default we select the fourth node. Use the table below" 1>&2
       ;;
     *)
       ;;
@@ -107,6 +102,7 @@ function get_nodeparameters(){
       # node_name -> node_name
       ;;
     "GCP")
+      # node_name -> node_name
       ;;
     *)
       ;;


### PR DESCRIPTION
Introduce two bash scripts that automatically create a CR example for `fence_aws`, `fence_ipmilan`, and `fence_azure_arm` based on the platform (`AWS`, `BareMetal`, or `Azure`).
The main script, _create_cr_example_, uses the CR kind (_FenceAgentsRemediation_/_FenceAgentsRemediationTemplate_), as the first parameter and operator installation namespace as the second parameter for creating an example CR.

In case of creating an example on the **AWS** platform, then please run `make ocp-aws-credentials` to add the CredentialsRequest for OCP on AWS.

**The scripts are tested and work on OCP**

[ECOPROJECT-1665](https://issues.redhat.com//browse/ECOPROJECT-1665)