### PR TITLE
Add fence_gce Agent for GCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=builder /workspace/manager .
 # Add Fence Agents and fence-agents-aws packages
 RUN dnf install -y dnf-plugins-core \
     && dnf config-manager --set-enabled ha \
-    && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm \
+    && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm fence-agents-gce \
     && dnf clean all -y
 
 USER 65532:65532


### PR DESCRIPTION
Adding a fence agent for Google Cloud Platform (GCP) platform - [fence_gce](https://www.mankier.com/8/fence_gce)