### PR TITLE
Add missing RBAC permissions

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -135,6 +135,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - nodes
           verbs:
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - delete

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -70,6 +70,7 @@ func (r *FenceAgentsRemediationReconciler) SetupWithManager(mgr ctrl.Manager) er
 //+kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;delete;deletecollection
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;delete
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/finalizers,verbs=update


### PR DESCRIPTION
When FAR is used with `fence_azure_arm` fence agent. It requires permissions for watching and listing the namespace objects for repairing unhealthy nodes. If the operator does not hold these permissions, the following error is shown and NHC stays in `Remediating` status :

```sh
2023-10-25T09:36:47.33411147Z	INFO	controllers.FenceAgentsRemediation	Manual workload deletion	{"Fence Agent": "fence_azure_arm", "Node Name": "jcano-cluster-9fnfq-worker-germanywestcentral1-m5nwt"}
W1025 09:36:47.336315       1 reflector.go:533] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:233: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:openshift-operators:fence-agents-remediation-controller-manager" cannot list resource "namespaces" in API group "" at the cluster scope
E1025 09:36:47.336350       1 reflector.go:148] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:233: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:openshift-operators:fence-agents-remediation-controller-manager" cannot list resource "namespaces" in API group "" at the cluster scope

```
It adds verbs `list` and `watch`  verbs for `namespace` resources.