### PR TITLE
Add Events for far Remediation Process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ test: test-no-verify verify-unchanged ## Generate and format code, run tests, ge
 # By default, ginkgo only randomizes the top level Describe, Context and When containers
 # --require-suite: If set, Ginkgo fails if there are ginkgo tests in a directory but no invocation of RunSpecs.
 # --vv: If set, emits with maximal verbosity - includes skipped and pending tests.
-test-no-verify: manifests generate go-verify fmt vet fix-imports envtest ginkgo # Generate and format code, and run tests
+test-no-verify: go-verify manifests generate fmt vet fix-imports envtest ginkgo # Generate and format code, and run tests
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_DIR)/$(ENVTEST_VERSION) -p path)" \
 	$(GINKGO) -r --keep-going --randomize-all --require-suite --vv --coverprofile cover.out ./pkg/... ./controllers/...
 

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -121,12 +121,12 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 
 	// Validate FAR CR name to match a nodeName from the cluster
 	r.Log.Info("Check FAR CR's name")
-	node, valid, err := utils.IsNodeNameValid(r.Client, req.Name)
+	node, err := utils.GetNodeWithName(r.Client, req.Name)
 	if err != nil {
 		r.Log.Error(err, "Unexpected error when validating CR's name with nodes' names", "CR's Name", req.Name)
 		return emptyResult, err
 	}
-	if !valid {
+	if node == nil {
 		r.Log.Error(err, "Didn't find a node matching the CR's name", "CR's Name", req.Name)
 		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
 		commonEvents.WarningEvent(r.Recorder, far, utils.EventReasonCrNodeNotFound, utils.EventMessageCrNodeNotFound)

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	commonAnnotations "github.com/medik8s/common/pkg/annotations"
 	commonConditions "github.com/medik8s/common/pkg/conditions"
+	commonEvents "github.com/medik8s/common/pkg/events"
 	commonResources "github.com/medik8s/common/pkg/resources"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilErrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -57,6 +59,7 @@ type FenceAgentsRemediationReconciler struct {
 	client.Client
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 	Executor *cli.Executer
 }
 
@@ -104,6 +107,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Failed to get FenceAgentsRemediation CR")
 		return emptyResult, err
 	}
+	commonEvents.RemediationStarted(r.Recorder, far)
 
 	// At the end of each Reconcile we try to update CR's status
 	defer func() {
@@ -125,14 +129,16 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 	if !valid {
 		r.Log.Error(err, "Didn't find a node matching the CR's name", "CR's Name", req.Name)
 		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
+		commonEvents.WarningEvent(r.Recorder, far, utils.EventReasonCrNodeNotFound, utils.EventMessageCrNodeNotFound)
 		return emptyResult, err
 	}
 
 	// Check NHC timeout annotation
 	if isTimedOutByNHC(far) {
-		r.Log.Info("FAR remediation was stopped by Node Healthcheck Operator")
+		r.Log.Info(utils.EventMessageRemediationStoppedByNHC)
 		r.Executor.Remove(far.GetUID())
 		utils.UpdateConditions(utils.RemediationInterruptedByNHC, far, r.Log)
+		commonEvents.RemediationStoppedByNHC(r.Recorder, far)
 		return emptyResult, err
 	}
 
@@ -145,6 +151,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Info("Finalizer was added", "CR Name", req.Name)
 
 		utils.UpdateConditions(utils.RemediationStarted, far, r.Log)
+		commonEvents.NormalEvent(r.Recorder, far, utils.EventReasonAddFinalizer, utils.EventMessageAddFinalizer)
 		return requeueImmediately, nil
 	} else if controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) && !far.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Delete CR only when a finalizer and DeletionTimestamp are set
@@ -169,6 +176,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 			return emptyResult, fmt.Errorf("failed to remove finalizer from CR - %w", err)
 		}
 		r.Log.Info("Finalizer was removed", "CR Name", req.Name)
+		commonEvents.NormalEvent(r.Recorder, far, utils.EventReasonRemoveFinalizer, utils.EventMessageRemoveFinalizer)
 		return emptyResult, nil
 	}
 	// Add FAR (medik8s) remediation taint
@@ -196,6 +204,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		cmd := append([]string{far.Spec.Agent}, faParams...)
 		r.Log.Info("Execute the fence agent", "Fence Agent", far.Spec.Agent, "Node Name", req.Name, "FAR uid", far.GetUID())
 		r.Executor.AsyncExecute(ctx, far.GetUID(), cmd, far.Spec.RetryCount, far.Spec.RetryInterval.Duration, far.Spec.Timeout.Duration)
+		commonEvents.NormalEvent(r.Recorder, far, utils.EventReasonFenceAgentExecuted, utils.EventMessageFenceAgentExecuted)
 		return emptyResult, nil
 	}
 
@@ -205,7 +214,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		// - try to remove workloads
 		// - clean up Executor routine
 
-		r.Log.Info("Manual workload deletion", "Fence Agent", far.Spec.Agent, "Node Name", req.Name)
+		r.Log.Info("Manual workload deletion", "Node Name", req.Name)
 		if err := commonResources.DeletePods(ctx, r.Client, req.Name); err != nil {
 			r.Log.Error(err, "Manual workload deletion has failed", "CR's Name", req.Name)
 			return emptyResult, err
@@ -214,6 +223,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 
 		r.Executor.Remove(far.GetUID())
 		r.Log.Info("FenceAgentsRemediation CR has completed to remediate the node", "Node Name", req.Name)
+		commonEvents.RemediationFinished(r.Recorder, far)
 	}
 
 	return emptyResult, nil

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -147,7 +147,7 @@ var _ = Describe("FAR Controller", func() {
 			Expect(k8sClient.Create(context.Background(), underTestFAR)).To(Succeed())
 			DeferCleanup(cleanupFar(), context.Background(), underTestFAR)
 
-			// Sleep for a second to ensure dummy reconicliation has begun running before the unit tests
+			// Sleep for a second to ensure dummy reconciliation has begun running before the unit tests
 			time.Sleep(1 * time.Second)
 		})
 

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -127,7 +127,7 @@ var _ = Describe("FAR Controller", func() {
 	})
 
 	Context("Reconcile", func() {
-		farRemediationTaint := utils.CreateFARRemediationTaint()
+		farRemediationTaint := utils.CreateRemediationTaint()
 		conditionStatusPointer := func(status metav1.ConditionStatus) *metav1.ConditionStatus { return &status }
 
 		BeforeEach(func() {
@@ -253,7 +253,7 @@ var _ = Describe("FAR Controller", func() {
 
 					By("Wait some retries")
 					Eventually(func() int {
-						return plogs.CountOccurences("command failed")
+						return plogs.CountOccurences(cli.FenceAgentFailedCommandMessage)
 					}, "10s", "1s").Should(BeNumerically(">", 3))
 
 					By("Deleting the CR")
@@ -311,7 +311,7 @@ var _ = Describe("FAR Controller", func() {
 
 					By("Reading the expected number of retries")
 					Eventually(func() int {
-						return plogs.CountOccurences("command failed")
+						return plogs.CountOccurences(cli.FenceAgentFailedCommandMessage)
 					}).Should(Equal(3))
 
 					By("Verifying correct conditions for un-successful remediation")
@@ -341,7 +341,7 @@ var _ = Describe("FAR Controller", func() {
 
 					By("Context timeout occurred")
 					Eventually(func() bool {
-						return plogs.Contains("fence agent context timed out")
+						return plogs.Contains(cli.FenceAgentContextTimedOutMessage)
 					}).Should(BeTrue(), "fence agent should have timed out")
 
 					By("Verifying correct conditions for un-successful remediation")

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -169,7 +169,7 @@ var _ = Describe("FAR Controller", func() {
 						"--ipport=6233"}))
 				}, timeoutPreRemediation, pollInterval).Should(Succeed())
 
-				underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, &farRemediationTaint)
+				underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, defaultNamespace, &farRemediationTaint)
 
 				By("Not having any test pod")
 				verifyPodDeleted(testPodName)
@@ -244,14 +244,14 @@ var _ = Describe("FAR Controller", func() {
 				})
 
 				It("should exit immediately without trying to update the status conditions", func() {
-					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, &farRemediationTaint)
+					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, defaultNamespace, &farRemediationTaint)
 
 					By("Wait some retries")
 					Eventually(func() int {
 						return plogs.CountOccurences(cli.FenceAgentFailedCommandMessage)
 					}, "10s", "1s").Should(BeNumerically(">", 3))
 
-					By("Deleting far CR")
+					By("Deleting FAR CR")
 					Expect(k8sClient.Delete(context.Background(), underTestFAR)).To(Succeed())
 
 					By("Verifying goroutine stopped without trying to update the conditions")
@@ -274,9 +274,9 @@ var _ = Describe("FAR Controller", func() {
 				})
 
 				It("should exit immediately without trying to update the status conditions", func() {
-					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, &farRemediationTaint)
+					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, defaultNamespace, &farRemediationTaint)
 
-					By("Deleting far CR")
+					By("Deleting FAR CR")
 					Expect(k8sClient.Delete(context.Background(), underTestFAR)).To(Succeed())
 
 					By("Verifying goroutine stopped without trying to update the conditions")
@@ -297,7 +297,7 @@ var _ = Describe("FAR Controller", func() {
 				})
 
 				It("should retry the fence agent command as configured and update the status accordingly", func() {
-					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, &farRemediationTaint)
+					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, defaultNamespace, &farRemediationTaint)
 
 					By("Still having one test pod")
 					verifyPodExists(testPodName)
@@ -327,7 +327,7 @@ var _ = Describe("FAR Controller", func() {
 				})
 
 				It("should stop Fence Agent execution and update the status accordingly", func() {
-					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, &farRemediationTaint)
+					underTestFAR = verifyPreRemediationSucceed(underTestFAR, workerNode, defaultNamespace, &farRemediationTaint)
 
 					By("Still having one test pod")
 					verifyPodExists(testPodName)
@@ -481,9 +481,9 @@ func verifyStatusCondition(far *v1alpha1.FenceAgentsRemediation, nodeName, condi
 }
 
 // verifyPreRemediationSucceed checks if the remediation CR already has a finazliaer and a remediation taint
-func verifyPreRemediationSucceed(underTestFAR *v1alpha1.FenceAgentsRemediation, nodeName string, taint *corev1.Taint) *v1alpha1.FenceAgentsRemediation {
+func verifyPreRemediationSucceed(underTestFAR *v1alpha1.FenceAgentsRemediation, nodeName, namespace string, taint *corev1.Taint) *v1alpha1.FenceAgentsRemediation {
 	By("Searching for finalizer ")
-	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: workerNode, Namespace: defaultNamespace}, underTestFAR)).To(Succeed())
+	Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: nodeName, Namespace: namespace}, underTestFAR)).To(Succeed())
 	Expect(controllerutil.ContainsFinalizer(underTestFAR, v1alpha1.FARFinalizer)).To(BeTrue())
 	verifyEvent(corev1.EventTypeNormal, utils.EventReasonAddFinalizer, utils.EventMessageAddFinalizer)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4
-	github.com/medik8s/common v1.9.0
+	github.com/medik8s/common v1.12.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/openshift/api v0.0.0-20230621174358-ea40115b9fa6

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/medik8s/common v1.9.0 h1:nMMffmj+e0l0xRB0RfpsbdDpW9upXU2MFeGGADJlwyE=
-github.com/medik8s/common v1.9.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
+github.com/medik8s/common v1.12.0 h1:UJ5VS4rbo/K0snfuqRiYam1NhXTwo4Q7fTng34YSlmA=
+github.com/medik8s/common v1.12.0/go.mod h1:Q6YR2rgyiLl6ob4Mx2uDBmybAB3d94fImwoHPbeiE54=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ import (
 	"github.com/medik8s/fence-agents-remediation/version"
 )
 
+const operatorName = "FenceAgentsRemediation"
+
 var (
 	scheme   = pkgruntime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -110,11 +112,12 @@ func main() {
 
 	if err = (&controllers.FenceAgentsRemediationReconciler{
 		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("FenceAgentsRemediation"),
+		Log:      ctrl.Log.WithName("controllers").WithName(operatorName),
 		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor(operatorName),
 		Executor: executer,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "FenceAgentsRemediation")
+		setupLog.Error(err, "unable to create controller", "controller", operatorName)
 		os.Exit(1)
 	}
 

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -28,6 +28,7 @@ const (
 	FenceAgentContextCanceledMessage = "fence agent context canceled. Nothing to do"
 	FenceAgentContextTimedOutMessage = "fence agent context timed out"
 	FenceAgentRetryErrorMessage      = "fence agent retry error"
+	FenceAgentFailedCommandMessage   = "command failed"
 )
 
 type routine struct {
@@ -135,7 +136,7 @@ func (e *Executer) runWithRetry(ctx context.Context, uid types.UID, command []st
 				return false, faErr
 			}
 
-			e.log.Info("command failed", "uid", uid, "response", stdout, "errMessage", stderr, "err", faErr)
+			e.log.Info(FenceAgentFailedCommandMessage, "uid", uid, "response", stdout, "errMessage", stderr, "err", faErr)
 			return false, nil
 		})
 

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	commonEvents "github.com/medik8s/common/pkg/events"
 
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +40,7 @@ type Executer struct {
 	routines     map[types.UID]*routine
 	routinesLock sync.Mutex
 	runner       runnerFunc
+	recorder     record.EventRecorder
 }
 
 // runnerFunc is a function that runs the command and returns the stdout, stderr and error
@@ -180,6 +183,7 @@ func (e *Executer) updateStatusWithRetry(ctx context.Context, uid types.UID, fen
 			}
 
 			e.log.Info("status updated", "FAR uid", uid)
+			commonEvents.NormalEvent(e.recorder, far, utils.EventReasonFenceAgentSucceeded, utils.EventMessageFenceAgentSucceeded)
 			return true, nil
 		})
 	return err

--- a/pkg/cli/fake.go
+++ b/pkg/cli/fake.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -9,11 +10,13 @@ import (
 // NewExecuter builds an Executer with configurable runnerFunc for testing
 func NewFakeExecuter(client client.Client, fn runnerFunc) (*Executer, error) {
 	logger := ctrl.Log.WithName("fakeExecuter")
+	fakeRecorder := record.NewFakeRecorder(10)
 
 	return &Executer{
 		Client:   client,
 		log:      logger,
 		routines: make(map[types.UID]*routine),
 		runner:   fn,
+		recorder: fakeRecorder,
 	}, nil
 }

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -17,7 +17,7 @@ const (
 	FenceAgentActionSucceededType = "FenceAgentActionSucceeded"
 	// condition messages
 	RemediationFinishedNodeNotFoundConditionMessage = "FAR CR name doesn't match a node name"
-	RemediationInterruptedByNHCConditionMessage     = "Node Healthcheck timeout annotation has been set"
+	RemediationInterruptedByNHCConditionMessage     = "Node Healthcheck timeout annotation has been set. Remediation has stopped"
 	RemediationStartedConditionMessage              = "FAR CR was found, its name matches one of the cluster nodes, and a finalizer was set to the CR"
 	FenceAgentSucceededConditionMessage             = "FAR taint was added and the fence agent command has been created and executed successfully"
 	FenceAgentFailedConditionMessage                = "Fence agent command has failed"

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -2,18 +2,26 @@ package utils
 
 const (
 	// events reasons
-	EventReasonCrNodeNotFound          = "NodeNotFound"
-	EventReasonRemediationStoppedByNHC = "RemediationStoppedByNHC"
-	EventReasonAddFinalizer            = "AddFinalizer"
-	EventReasonRemoveFinalizer         = "RemoveFinalizer"
-	EventReasonFenceAgentExecuted      = "FenceAgentExecuted"
-	EventReasonFenceAgentSucceeded     = "FenceAgentSucceeded"
+	EventReasonCrNodeNotFound           = "NodeNotFound"
+	EventReasonRemediationStoppedByNHC  = "RemediationStoppedByNHC"
+	EventReasonAddFinalizer             = "AddFinalizer"
+	EventReasonRemoveRemediationTaint   = "RemoveRemediationTaint"
+	EventReasonRemoveFinalizer          = "RemoveFinalizer"
+	EventReasonAddRemediationTaint      = "AddRemediationTaint"
+	EventReasonFenceAgentExecuted       = "FenceAgentExecuted"
+	EventReasonFenceAgentSucceeded      = "FenceAgentSucceeded"
+	EventReasonDeleteResources          = "DeleteResources"
+	EventReasonNodeRemediationCompleted = "NodeRemediationCompleted"
 
 	// events messages
-	EventMessageCrNodeNotFound          = "CR name doesn't match a node name"
-	EventMessageRemediationStoppedByNHC = "Remediation was stopped by the Node Healthcheck Operator"
-	EventMessageAddFinalizer            = "Finalizer was added"
-	EventMessageRemoveFinalizer         = "Finalizer was removed"
-	EventMessageFenceAgentExecuted      = "Fence agent was executed"
-	EventMessageFenceAgentSucceeded     = "Fence agent was succeeded"
+	EventMessageCrNodeNotFound           = "CR name doesn't match a node name"
+	EventMessageRemediationStoppedByNHC  = "Remediation was stopped by the Node Healthcheck Operator"
+	EventMessageAddFinalizer             = "Finalizer was added"
+	EventMessageRemoveRemediationTaint   = "Remediation taint was removed"
+	EventMessageRemoveFinalizer          = "Finalizer was removed"
+	EventMessageAddRemediationTaint      = "Remediation taint was added"
+	EventMessageFenceAgentExecuted       = "Fence agent was executed"
+	EventMessageFenceAgentSucceeded      = "Fence agent was succeeded"
+	EventMessageDeleteResources          = "Manually delete pods from the unhealthy node"
+	EventMessageNodeRemediationCompleted = "Unhealthy node remediation was completed"
 )

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -1,0 +1,19 @@
+package utils
+
+const (
+	// events reasons
+	EventReasonCrNodeNotFound          = "NodeNotFound"
+	EventReasonRemediationStoppedByNHC = "RemediationStoppedByNHC"
+	EventReasonAddFinalizer            = "AddFinalizer"
+	EventReasonRemoveFinalizer         = "RemoveFinalizer"
+	EventReasonFenceAgentExecuted      = "FenceAgentExecuted"
+	EventReasonFenceAgentSucceeded     = "FenceAgentSucceeded"
+
+	// events messages
+	EventMessageCrNodeNotFound          = "CR name doesn't match a node name"
+	EventMessageRemediationStoppedByNHC = "Remediation was stopped by the Node Healthcheck Operator"
+	EventMessageAddFinalizer            = "Finalizer was added"
+	EventMessageRemoveFinalizer         = "Finalizer was removed"
+	EventMessageFenceAgentExecuted      = "Fence agent was executed"
+	EventMessageFenceAgentSucceeded     = "Fence agent was succeeded"
+)

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -22,17 +22,17 @@ func GetNodeWithName(r client.Reader, nodeName string) (*corev1.Node, error) {
 }
 
 // IsNodeNameValid returns an error if nodeName doesn't match any node name int the cluster, otherwise a nil
-func IsNodeNameValid(r client.Reader, nodeName string) (bool, error) {
-	_, err := GetNodeWithName(r, nodeName)
+func IsNodeNameValid(r client.Reader, nodeName string) (*corev1.Node, bool, error) {
+	node, err := GetNodeWithName(r, nodeName)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			// In case of notFound API error we don't return error, since it is valid result
-			return false, nil
+			return node, false, nil
 		} else {
-			return false, err
+			return node, false, err
 		}
 	}
-	return true, nil
+	return node, true, nil
 }
 
 // GetNode returns a node object with the name nodeName based on the nodeType input

--- a/pkg/utils/nodes.go
+++ b/pkg/utils/nodes.go
@@ -16,23 +16,14 @@ func GetNodeWithName(r client.Reader, nodeName string) (*corev1.Node, error) {
 	node := &corev1.Node{}
 	key := client.ObjectKey{Name: nodeName}
 	if err := r.Get(context.TODO(), key, node); err != nil {
-		return nil, err
-	}
-	return node, nil
-}
-
-// IsNodeNameValid returns an error if nodeName doesn't match any node name int the cluster, otherwise a nil
-func IsNodeNameValid(r client.Reader, nodeName string) (*corev1.Node, bool, error) {
-	node, err := GetNodeWithName(r, nodeName)
-	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			// In case of notFound API error we don't return error, since it is valid result
-			return node, false, nil
+			return nil, nil
 		} else {
-			return node, false, err
+			return nil, err
 		}
 	}
-	return node, true, nil
+	return node, nil
 }
 
 // GetNode returns a node object with the name nodeName based on the nodeType input

--- a/pkg/utils/nodes_test.go
+++ b/pkg/utils/nodes_test.go
@@ -24,12 +24,14 @@ var _ = Describe("Utils-nodes", func() {
 		})
 		When("FAR CR's name doesn't match to an existing node name", func() {
 			It("should fail", func() {
-				Expect(IsNodeNameValid(k8sClient, dummyNode)).To(BeFalse())
+				_, isMatch, _ := IsNodeNameValid(k8sClient, dummyNode)
+				Expect(isMatch).To(BeFalse())
 			})
 		})
 		When("FAR's name does match to an existing node name", func() {
 			It("should succeed", func() {
-				Expect(IsNodeNameValid(k8sClient, node01)).To(BeTrue())
+				_, isMatch, _ := IsNodeNameValid(k8sClient, node01)
+				Expect(isMatch).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/utils/nodes_test.go
+++ b/pkg/utils/nodes_test.go
@@ -24,14 +24,12 @@ var _ = Describe("Utils-nodes", func() {
 		})
 		When("FAR CR's name doesn't match to an existing node name", func() {
 			It("should fail", func() {
-				_, isMatch, _ := IsNodeNameValid(k8sClient, dummyNode)
-				Expect(isMatch).To(BeFalse())
+				Expect(GetNodeWithName(k8sClient, dummyNode)).To(BeNil())
 			})
 		})
 		When("FAR's name does match to an existing node name", func() {
 			It("should succeed", func() {
-				_, isMatch, _ := IsNodeNameValid(k8sClient, node01)
-				Expect(isMatch).To(BeTrue())
+				Expect(GetNodeWithName(k8sClient, node01)).ToNot(BeNil())
 			})
 		})
 	})

--- a/pkg/utils/taint_test.go
+++ b/pkg/utils/taint_test.go
@@ -16,7 +16,7 @@ const node0 = "worker-0"
 var _ = Describe("Utils-taint", func() {
 	nodeKey := client.ObjectKey{Name: node0}
 	controlPlaneRoleTaint := getControlPlaneRoleTaint()
-	farNoExecuteTaint := CreateFARNoExecuteTaint()
+	farNoExecuteTaint := CreateFARRemediationTaint()
 	Context("Taint functioninality test", func() {
 		// Check functionaility with control-plane node which already has a taint
 		BeforeEach(func() {
@@ -31,7 +31,7 @@ var _ = Describe("Utils-taint", func() {
 				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
 				// control-plane-role taint already exist by GetNode
 				By("adding medik8s NoSchedule taint")
-				Expect(AppendTaint(k8sClient, node0)).To(Succeed())
+				Expect(AppendTaint(k8sClient, node0)).Error().NotTo(HaveOccurred())
 				Expect(k8sClient.Get(context.Background(), nodeKey, taintedNode)).To(Succeed())
 				Expect(TaintExists(taintedNode.Spec.Taints, &controlPlaneRoleTaint)).To(BeTrue())
 				Expect(TaintExists(taintedNode.Spec.Taints, &farNoExecuteTaint)).To(BeTrue())

--- a/pkg/utils/taint_test.go
+++ b/pkg/utils/taint_test.go
@@ -16,7 +16,7 @@ const node0 = "worker-0"
 var _ = Describe("Utils-taint", func() {
 	nodeKey := client.ObjectKey{Name: node0}
 	controlPlaneRoleTaint := getControlPlaneRoleTaint()
-	farNoExecuteTaint := CreateFARRemediationTaint()
+	farNoExecuteTaint := CreateRemediationTaint()
 	Context("Taint functioninality test", func() {
 		// Check functionaility with control-plane node which already has a taint
 		BeforeEach(func() {

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -43,8 +43,8 @@ func deleteTaint(taints []corev1.Taint, taintToDelete *corev1.Taint) ([]corev1.T
 	return newTaints, deleted
 }
 
-// CreateFARRemediationTaint returns a remediation NoExeucte taint
-func CreateFARRemediationTaint() corev1.Taint {
+// CreateRemediationTaint returns a remediation NoExeucte taint
+func CreateRemediationTaint() corev1.Taint {
 	return corev1.Taint{
 		Key:    v1alpha1.FARNoExecuteTaintKey,
 		Effect: corev1.TaintEffectNoExecute,
@@ -60,7 +60,7 @@ func AppendTaint(r client.Client, nodeName string) (bool, error) {
 		return false, err
 	}
 
-	taint := CreateFARRemediationTaint()
+	taint := CreateRemediationTaint()
 	// check if taint doesn't exist
 	if TaintExists(node.Spec.Taints, &taint) {
 		return false, nil
@@ -87,7 +87,7 @@ func RemoveTaint(r client.Client, nodeName string) error {
 		return err
 	}
 
-	taint := CreateFARRemediationTaint()
+	taint := CreateRemediationTaint()
 	// check if taint exist
 	if !TaintExists(node.Spec.Taints, &taint) {
 		return nil

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -56,7 +56,7 @@ func CreateFARRemediationTaint() corev1.Taint {
 func AppendTaint(r client.Client, nodeName string) (bool, error) {
 	// find node by name
 	node, err := GetNodeWithName(r, nodeName)
-	if err != nil {
+	if node == nil {
 		return false, err
 	}
 
@@ -83,7 +83,7 @@ func AppendTaint(r client.Client, nodeName string) (bool, error) {
 func RemoveTaint(r client.Client, nodeName string) error {
 	// find node by name
 	node, err := GetNodeWithName(r, nodeName)
-	if err != nil {
+	if node == nil {
 		return err
 	}
 

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -300,6 +300,7 @@ func wasFarTaintAdded(nodeName string) {
 		var err error
 		node, err = utils.GetNodeWithName(k8sClient, nodeName)
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(node).ToNot(BeNil())
 		return utils.TaintExists(node.Spec.Taints, &farTaint)
 	}, timeoutTaint, pollTaint).Should(BeTrue())
 	log.Info("FAR taint was added", "node name", node.Name, "taint key", farTaint.Key, "taint effect", farTaint.Effect)

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -294,7 +294,7 @@ func cleanupTestedResources(pod *corev1.Pod) {
 
 // wasFarTaintAdded checks whether the FAR taint was added to the tested node
 func wasFarTaintAdded(nodeName string) {
-	farTaint := utils.CreateFARNoExecuteTaint()
+	farTaint := utils.CreateFARRemediationTaint()
 	var node *corev1.Node
 	Eventually(func(g Gomega) bool {
 		var err error

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -294,7 +294,7 @@ func cleanupTestedResources(pod *corev1.Pod) {
 
 // wasFarTaintAdded checks whether the FAR taint was added to the tested node
 func wasFarTaintAdded(nodeName string) {
-	farTaint := utils.CreateFARRemediationTaint()
+	farTaint := utils.CreateRemediationTaint()
 	var node *corev1.Node
 	Eventually(func(g Gomega) bool {
 		var err error

--- a/vendor/github.com/medik8s/common/pkg/events/events.go
+++ b/vendor/github.com/medik8s/common/pkg/events/events.go
@@ -1,0 +1,51 @@
+package events
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+// Event message format "medik8s <operator shortname> <message>"
+const customFmt = "[remediation] %s"
+
+// NormalEvent will record an event with type Normal and fixed message.
+func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
+	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
+}
+
+// NormalEventf will record an event with type Normal and formatted message.
+func NormalEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
+	message := fmt.Sprintf(messageFmt, a...)
+	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
+}
+
+// WarningEvent will record an event with type Warning and fixed message.
+func WarningEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
+	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
+}
+
+// WarningEventf will record an event with type Warning and formatted message.
+func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason, messageFmt string, a ...interface{}) {
+	message := fmt.Sprintf(messageFmt, a...)
+	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
+}
+
+// Special case events
+
+// RemediationStarted will record a Normal event with reason RemediationStarted and message Remediation started.
+func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
+}
+
+// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped.
+func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
+}
+
+// RemediationFinished will record a Normal event with reason RemediationFinished and message Remediation finished.
+func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
+	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+}

--- a/vendor/github.com/medik8s/common/pkg/labels/labels.go
+++ b/vendor/github.com/medik8s/common/pkg/labels/labels.go
@@ -7,4 +7,8 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
+	// DefaultTemplate label indicates to third party tools (e.g. UI) the default remediation template in case several exists.
+	DefaultTemplate = "remediation.medik8s.io/default-template"
+	// ExcludeFromRemediation label would be put on a node with value "true" in order to indicate this node should not be remediated.
+	ExcludeFromRemediation = "remediation.medik8s.io/exclude-from-remediation"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -92,10 +92,11 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0
 ## explicit; go 1.19
 github.com/matttproud/golang_protobuf_extensions/v2/pbutil
-# github.com/medik8s/common v1.9.0
+# github.com/medik8s/common v1.12.0
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/annotations
 github.com/medik8s/common/pkg/conditions
+github.com/medik8s/common/pkg/events
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/resources
 # github.com/moby/spdystream v0.2.0


### PR DESCRIPTION
To ease the tracking of the remediation process of far [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) we add events to indicate major milestones (such as fencing, workload deletion, etc.)

1. Adding events (and unit testing)
2. Check whether NoExecute taint was added to signal an event. 
3. Only use `GetNodeWithName` instead of `IsNodeNameValid` which is no longer needed.
4. Small refactoring to unit tests

[ECOPROJECT-1663](https://issues.redhat.com//browse/ECOPROJECT-1663)