### PR TITLE
rapidast scan execution as kuttl testsuite

### DIFF
--- a/test/e2e-rh-sdl/Dockerfile
+++ b/test/e2e-rh-sdl/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.20-bullseye
+
+# Copy the repository files
+COPY . /tmp/fence-agents-remediation-qe
+
+WORKDIR /tmp
+
+# Set the Go path and Go cache environment variables
+ENV GOPATH=/tmp/go
+ENV GOBIN=/tmp/go/bin
+ENV GOCACHE=/tmp/.cache/go-build
+ENV PATH=$PATH:$GOBIN
+
+# Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
+RUN mkdir -p /tmp/go/bin $GOCACHE \
+    && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
+
+# Install dependencies required by test cases and debugging
+RUN apt-get update && apt-get install -y jq vim libreadline-dev dnsutils iproute2 python
+
+# Install kuttl
+RUN curl -LO https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 \
+    && chmod +x kubectl-kuttl_0.15.0_linux_x86_64 \
+    && mv kubectl-kuttl_0.15.0_linux_x86_64 /usr/local/bin/kuttl
+
+# Install kubectl and oc
+RUN curl -LO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz \
+    && tar -xzf openshift-client-linux.tar.gz \
+    && chmod +x oc kubectl \
+    && mv oc kubectl /usr/local/bin/
+
+# Set the working directory
+WORKDIR /tmp/fence-agents-remediation-qe

--- a/test/e2e-rh-sdl/README.md
+++ b/test/e2e-rh-sdl/README.md
@@ -1,0 +1,23 @@
+# rapidast execution for fence-agents-remediation operator
+
+This test is running [rapidast](https://github.com/RedHatProductSecurity/rapidast) scan targeting the api extension that the fence-agents-remediation operator
+provides to the openshift api.
+
+The test steps ensure the generation of the needed token to retrieve the api extension urls, customize the
+rapidast config file, runs the scan in a docker instance and check for the results.
+
+Follow these step to run manually the scan inside the container:
+
+* Create the container image:
+
+`cd test/e2e-rh-sdl`
+
+`podman build . -t e2e-rh-sdl`
+
+* Run the container (adapt the kubeconfig file path to your environment):
+
+`podman run -it -v ~/clusterconfigs/auth/:/kube/config:Z --env KUBECONFIG=/kube/config/kubeconfig e2e-rh-sdl /bin/bash`
+
+* Launch the scan using kuttl utility:
+
+`ARTIFACT_DIR=/tmp KUBECONFIG=$KUBECONFIG kuttl test --timeout=300 --test=far rapidast/`

--- a/test/e2e-rh-sdl/rapidast/far/00-assert.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/00-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  labels:
+    kubernetes.io/metadata.name: rapidast-far
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: rapidast-far
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/test/e2e-rh-sdl/rapidast/far/00-create-project.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/00-create-project.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rapidast-far
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"

--- a/test/e2e-rh-sdl/rapidast/far/01-assert.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/01-assert.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: privileged-sa
+  namespace: rapidast-far
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-far-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-far
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-far-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-far

--- a/test/e2e-rh-sdl/rapidast/far/01-create-sa.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/01-create-sa.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: privileged-sa
+  namespace: rapidast-far
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-far-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-far
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rapidast-far-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: privileged-sa
+  namespace: rapidast-far

--- a/test/e2e-rh-sdl/rapidast/far/02-assert.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rapidast-configmap
+  namespace: rapidast-far

--- a/test/e2e-rh-sdl/rapidast/far/02-create-rapidast-config.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/02-create-rapidast-config.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: ./create_rapidast_configmap.sh

--- a/test/e2e-rh-sdl/rapidast/far/03-assert.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/03-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-job
+  namespace: rapidast-far
+status:
+  succeeded: 1

--- a/test/e2e-rh-sdl/rapidast/far/03-rapidast-job.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/03-rapidast-job.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rapidast-pvc
+  namespace: rapidast-far
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-job
+  namespace: rapidast-far
+spec:
+  backoffLimit: 3
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
+  suspend: false
+  template:
+    metadata:
+      labels:
+        job-name: rapidast-job
+      name: rapidast-job
+    spec:
+      serviceAccount: privileged-sa
+      serviceAccountName: privileged-sa
+      containers:
+      - command:
+        - sh
+        - -c
+        - rapidast.py --log-level debug --config /helm/config/rapidastconfig.yaml && find /home/rapidast/results/far -name zap-report.json -exec cat {} \;
+        image: quay.io/redhatproductsecurity/rapidast:latest
+        imagePullPolicy: Always
+        name: rapidast-chart
+        resources: {}
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /helm/config
+          name: config-volume
+        - mountPath: /home/rapidast/results/
+          name: results-volume
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: rapidast-configmap
+        name: config-volume
+      - name: results-volume
+        persistentVolumeClaim:
+          claimName: rapidast-pvc

--- a/test/e2e-rh-sdl/rapidast/far/04-assert.yaml
+++ b/test/e2e-rh-sdl/rapidast/far/04-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 180
+commands:
+- script: ./rapidast/far/results.sh

--- a/test/e2e-rh-sdl/rapidast/far/create_rapidast_configmap.sh
+++ b/test/e2e-rh-sdl/rapidast/far/create_rapidast_configmap.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eou pipefail
 
 NAMESPACE="rapidast-far"
-# API_CLUSTER="https://kubernetes.default.svc"
 API_CLUSTER=$(grep "server: https://" $KUBECONFIG | sed -r 's#.+?//##' | head -1)
-# TOKEN=$(oc login -u kubeadmin -p $(cat ${HOME}/clusterconfigs/auth/kubeadmin-password) --server=https://${API_CLUSTER} > /dev/null 2>&1 ; oc whoami -t)
 TOKEN=$(oc create token privileged-sa -n rapidast-far)
 API_CLUSTER_NAME=$(echo $API_CLUSTER | cut -d ':' -f 1)
 OAST_CALLBACK_PORT=$(python -c "import socket; s=socket.socket(); s.bind((\"\", 0)); print(s.getsockname()[1]); s.close()")

--- a/test/e2e-rh-sdl/rapidast/far/results.sh
+++ b/test/e2e-rh-sdl/rapidast/far/results.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -eou pipefail
 
 # Temp directory to store generated pod yaml
 TMP_DIR=/tmp

--- a/test/e2e-rh-sdl/rapidast/far/results.sh
+++ b/test/e2e-rh-sdl/rapidast/far/results.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Temp directory to store generated pod yaml
+TMP_DIR=/tmp
+
+# Where to store sync'd results -- defaults to current dir
+ARTIFACT_DIR=${ARTIFACT_DIR}
+
+# Name for rapiterm pod
+RANDOM_NAME=rapiterm-$RANDOM
+
+# Name of PVC in RapiDAST Resource, i.e. which PVC to mount to grab results
+PVC=rapidast-pvc
+
+IMAGE_REPOSITORY=quay.io/redhatproductsecurity/rapidast-term
+IMAGE_TAG=latest
+NAMESPACE=rapidast-far
+
+cat <<EOF > $TMP_DIR/$RANDOM_NAME
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $RANDOM_NAME
+  namespace: $NAMESPACE
+spec:
+  containers:
+    - name: terminal
+      image: '$IMAGE_REPOSITORY:$IMAGE_TAG'
+      command: ['sleep', '300']
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: results-volume
+          mountPath: /zap/results/
+      resources:
+        limits:
+          cpu: 100m
+          memory: 500Mi
+        requests:
+          cpu: 50m
+          memory: 100Mi
+  volumes:
+    - name: results-volume
+      persistentVolumeClaim:
+        claimName: $PVC
+EOF
+
+kubectl apply -f $TMP_DIR/$RANDOM_NAME
+rm $TMP_DIR/$RANDOM_NAME
+kubectl -n $NAMESPACE wait --for=condition=Ready pod/$RANDOM_NAME
+kubectl -n $NAMESPACE cp $RANDOM_NAME:/zap/results $ARTIFACT_DIR
+
+# Function to search for 'session' file and zap-report.json recursively
+search_for_files() {
+  local dir="$1/far"
+  local found_session=0
+  local found_zap_report=0
+
+  while IFS= read -r -d '' file; do
+    if [[ "$file" == *"session"* ]]; then
+      found_session=1
+    elif [[ "$file" == *"zap-report.json" ]]; then
+      found_zap_report=1
+    fi
+  done < <(find "$dir" -type f \( -name "session*" -o -name "zap-report.json" \) -print0)
+
+  if [[ "$found_session" -eq 0 || "$found_zap_report" -eq 0 ]]; then
+    echo "Either 'session' file or 'zap-report.json' files not found in subdirectories of $dir, failing..."
+    exit 1
+  fi
+}
+
+# Search for 'session' file and zap-report.json in subdirectories of $ARTIFACT_DIR
+search_for_files "$ARTIFACT_DIR"
+


### PR DESCRIPTION
Adding a new test folder that implements the execution of the dynamic security scan targeting the fence-agents-remediation api extension, based in the rapidast testing tool.
The Dockerfile file is prepared to fullfill all test dependencies in order to be run in ci-operator pipeline for openshift releases.