### PR TITLE
Delete Pods with Zero Grace Period

### DIFF
--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -49,6 +49,7 @@ const (
 	vaName1        = "va-test-1"
 	vaName2        = "va-test-2"
 
+	forced client.GracePeriodSeconds = 0
 	// intervals
 	timeoutDeletion  = 2 * time.Second // this timeout is used after all the other steps have finished successfully
 	timeoutFinalizer = 1 * time.Second
@@ -285,7 +286,7 @@ func cleanupTestedResources(va1, va2 *storagev1.VolumeAttachment, pod *corev1.Po
 	podTest := &corev1.Pod{}
 	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(pod), podTest); err == nil {
 		log.Info("Cleanup: clean pod", "pod name", podTest.Name)
-		Expect(k8sClient.Delete(context.Background(), podTest)).To(Succeed())
+		Expect(k8sClient.Delete(context.Background(), podTest, forced)).To(Succeed())
 	}
 }
 

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -37,6 +37,7 @@ const (
 	testContainerName        = "test-container"
 	testPodName              = "test-pod"
 
+	forced client.GracePeriodSeconds = 0
 	//TODO: try to minimize timeout
 	// eventually parameters
 	timeoutLogs     = 3 * time.Minute
@@ -268,7 +269,7 @@ func deleteFAR(far *v1alpha1.FenceAgentsRemediation) {
 func cleanupTestedResources(pod *corev1.Pod) {
 	newPod := &corev1.Pod{}
 	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(pod), newPod); err == nil {
-		Expect(k8sClient.Delete(context.Background(), newPod)).To(Succeed())
+		Expect(k8sClient.Delete(context.Background(), newPod, forced)).To(Succeed())
 		log.Info("cleanup: Pod has not been deleted by remediation", "pod name", pod.Name)
 	}
 }


### PR DESCRIPTION
Delete remaining test pods with zero grace. 
Avoid the `object is being deleted: pods far-pod-test-1 already exists` error.