### PR TITLE
High Availability for pod with 2 replicas

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -221,7 +221,7 @@ spec:
           control-plane: controller-manager
         name: fence-agents-remediation-controller-manager
         spec:
-          replicas: 1
+          replicas: 2
           selector:
             matchLabels:
               app.kubernetes.io/name: fence-agents-remediation-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:


### PR DESCRIPTION
FAR remediation time can be long when the FAR pod is evicted, and minimize this transition time by providing high availability to the FAR manager container (or simply FAR pod). 
To resolve it FAR pod will be running with 2 replicas.

https://issues.redhat.com/browse/ECOPROJECT-1496

