### PR TITLE
Set Suggested Namespace

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -50,6 +50,7 @@ metadata:
       fence-agents.
     olm.skipRange: '>=0.0.1'
     operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/fence-agents-remediation

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -49,6 +49,7 @@ metadata:
     description: Fence Agents Remediation Operator for remediating nodes using upstream
       fence-agents.
     olm.skipRange: '>=0.0.1'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/fence-agents-remediation

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
       fence-agents.
     olm.skipRange: '>=0.0.1'
     operatorframework.io/suggested-namespace: openshift-workload-availability
+    operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     repository: https://github.com/medik8s/fence-agents-remediation
     support: Medik8s
   name: fence-agents-remediation.v0.0.0

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -10,6 +10,7 @@ metadata:
     description: Fence Agents Remediation Operator for remediating nodes using upstream
       fence-agents.
     olm.skipRange: '>=0.0.1'
+    operatorframework.io/suggested-namespace: openshift-workload-availability
     repository: https://github.com/medik8s/fence-agents-remediation
     support: Medik8s
   name: fence-agents-remediation.v0.0.0


### PR DESCRIPTION
The suggested namespace is used to resolve the confusion of installing the operator from the console vs CLI.
We use two new [OCP annotations](https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-other_osdk-generating-csvs) for this matter and to make sure that `"openshift.io/node-selector":""` annotation is set on the installed namespace.

Similar to https://github.com/medik8s/self-node-remediation/pull/165, https://github.com/medik8s/self-node-remediation/pull/168, https://github.com/medik8s/node-maintenance-operator/pull/107 and related to [ECOPROJECT-1777](https://issues.redhat.com//browse/ECOPROJECT-1777)