### PR TITLE
Set Replace Annotation

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -372,4 +372,5 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: fence-agents-remediation.v0.0.1
   version: 0.0.1

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -124,4 +124,5 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: fence-agents-remediation.v0.0.1
   version: 0.0.0


### PR DESCRIPTION
Even though we use 'skipRange' for defining from which versions we can update to the version of the CSV, we also need to add the 'replace' field. It should point to the last released version and ensure that the old version isn't deleted from the index.

[docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-SkipRange](https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-SkipRange)

Similar to https://github.com/medik8s/self-node-remediation/pull/167, https://github.com/medik8s/node-maintenance-operator/pull/108 and related to [ECOPROJECT-1771](https://issues.redhat.com//browse/ECOPROJECT-1771)