### PR TITLE
Restrict Fence Agent Command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,9 @@ RUN dnf install -y dnf-plugins-core \
     && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm fence-agents-gce \
     && dnf clean all -y
 
+# Store the avavliable agents names (fence_*) into readonly fence_agents_list file
+RUN ls /usr/sbin/fence* > fence_agents_list \
+    && chmod 444 fence_agents_list
+
 USER 65532:65532
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN dnf install -y dnf-plugins-core \
     && dnf clean all -y
 
 # Store the avavliable agents names (fence_*) into readonly fence_agents_list file
-RUN ls /usr/sbin/fence_* | grep -oP '(?<=/usr/sbin/)(fence_[^/]*)' > fence_agents_list \
+RUN ls basename /usr/sbin | grep fence_ > fence_agents_list \
     && chmod 444 fence_agents_list
 
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN dnf install -y dnf-plugins-core \
     && dnf clean all -y
 
 # Store the avavliable agents names (fence_*) into readonly fence_agents_list file
-RUN ls /usr/sbin/fence* > fence_agents_list \
+RUN ls /usr/sbin/fence_* | grep -oP '(?<=/usr/sbin/)(fence_[^/]*)' > fence_agents_list \
     && chmod 444 fence_agents_list
 
 USER 65532:65532

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -134,15 +134,17 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	executor, _ := cli.NewFakeExecuter(k8sClient, controlledRun)
+	fakeExecutor, _ := cli.NewFakeExecuter(k8sClient, controlledRun)
 
 	os.Setenv("DEPLOYMENT_NAMESPACE", defaultNamespace)
 
+	agentsList := []string{"fence_ipmilan"}
 	err = (&FenceAgentsRemediationReconciler{
-		Client:   k8sClient,
-		Log:      k8sManager.GetLogger().WithName("test far reconciler"),
-		Scheme:   k8sManager.GetScheme(),
-		Executor: executor,
+		Client:     k8sClient,
+		Log:        k8sManager.GetLogger().WithName("test far reconciler"),
+		Scheme:     k8sManager.GetScheme(),
+		Executor:   fakeExecutor,
+		AgentsList: agentsList,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -140,11 +140,11 @@ var _ = BeforeSuite(func() {
 
 	agentsList := []string{"fence_ipmilan"}
 	err = (&FenceAgentsRemediationReconciler{
-		Client:     k8sClient,
-		Log:        k8sManager.GetLogger().WithName("test far reconciler"),
-		Scheme:     k8sManager.GetScheme(),
-		Executor:   fakeExecutor,
-		AgentsList: agentsList,
+		Client:          k8sClient,
+		Log:             k8sManager.GetLogger().WithName("test far reconciler"),
+		Scheme:          k8sManager.GetScheme(),
+		Executor:        fakeExecutor,
+		AgentsWhiteList: agentsList,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -97,7 +97,7 @@ var _ = Describe("FAR Controller", func() {
 		})
 
 		Context("buildFenceAgentParams", func() {
-			When("far CR include different action than reboot", func() {
+			When("FAR CR include different action than reboot", func() {
 				It("should succeed with a warning", func() {
 					invalidValTestFAR := getFenceAgentsRemediation(workerNode, fenceAgentIPMI, invalidShareParam, testNodeParam)
 					invalidShareString, err := buildFenceAgentParams(invalidValTestFAR)
@@ -109,7 +109,7 @@ var _ = Describe("FAR Controller", func() {
 					Expect(invalidShareString).To(ConsistOf(validShareString))
 				})
 			})
-			When("far CR's name doesn't match a node name", func() {
+			When("FAR CR's name doesn't match a node name", func() {
 				It("should fail", func() {
 					underTestFAR.ObjectMeta.Name = dummyNode
 					_, err := buildFenceAgentParams(underTestFAR)
@@ -117,7 +117,7 @@ var _ = Describe("FAR Controller", func() {
 					Expect(err).To(Equal(errors.New(errorMissingNodeParams)))
 				})
 			})
-			When("far CR's name does match a node name", func() {
+			When("FAR CR's name does match a node name", func() {
 				It("should succeed", func() {
 					underTestFAR.ObjectMeta.Name = workerNode
 					Expect(buildFenceAgentParams(underTestFAR)).Error().NotTo(HaveOccurred())
@@ -150,7 +150,7 @@ var _ = Describe("FAR Controller", func() {
 			DeferCleanup(cleanupFar(), context.Background(), underTestFAR)
 		})
 
-		When("creating valid far CR", func() {
+		When("creating valid FAR CR", func() {
 			BeforeEach(func() {
 				node = utils.GetNode("", workerNode)
 				underTestFAR = getFenceAgentsRemediation(workerNode, fenceAgentIPMI, testShareParam, testNodeParam)
@@ -188,14 +188,14 @@ var _ = Describe("FAR Controller", func() {
 			})
 		})
 
-		When("creating far CR with invalid name", func() {
+		When("creating FAR CR with invalid name", func() {
 			BeforeEach(func() {
 				node = utils.GetNode("", workerNode)
 				underTestFAR = getFenceAgentsRemediation(dummyNode, fenceAgentIPMI, testShareParam, testNodeParam)
 			})
 
 			It("should not have a finalizer nor taint, while the two VAs and one pod will remain", func() {
-				By("Not finding a matching node to far CR's name")
+				By("Not finding a matching node to FAR CR's name")
 				Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: underTestFAR.Name}, node)).To(Not(Succeed()))
 
 				By("Not having finalizer")
@@ -220,7 +220,7 @@ var _ = Describe("FAR Controller", func() {
 					conditionStatusPointer(metav1.ConditionFalse)) // SucceededTypeStatus
 			})
 		})
-		When("creating far CR with invalid fence agent name", func() {
+		When("creating FAR CR with invalid fence agent name", func() {
 			BeforeEach(func() {
 				node = utils.GetNode("", workerNode)
 				underTestFAR = getFenceAgentsRemediation(workerNode, fenceAgentUnknown, testShareParam, testNodeParam)

--- a/main.go
+++ b/main.go
@@ -121,10 +121,11 @@ func main() {
 	}
 
 	if err = (&controllers.FenceAgentsRemediationReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("FenceAgentsRemediation"),
-		Scheme:   mgr.GetScheme(),
-		Executor: executer,
+		Client:     mgr.GetClient(),
+		Log:        ctrl.Log.WithName("controllers").WithName("FenceAgentsRemediation"),
+		Scheme:     mgr.GetScheme(),
+		Executor:   executer,
+		AgentsList: agentList,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FenceAgentsRemediation")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -82,12 +82,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	printVersion()
-	agentList, err := getFenceAgents(AGENTS_FILE)
+	agentsList, err := getFenceAgents(AGENTS_FILE)
 	if err != nil {
 		setupLog.Error(err, "unable to check whether the fence agent file exists")
 		os.Exit(1)
 	}
-	printSupportedFenceAgents(agentList)
+	printSupportedFenceAgents(agentsList)
 
 	// Disable HTTP/2 support to avoid issues with CVE HTTP/2 Rapid Reset.
 	// Currently, the metrics server enables/disables HTTP/2 support only if SecureServing is enabled, which is not.
@@ -121,11 +121,11 @@ func main() {
 	}
 
 	if err = (&controllers.FenceAgentsRemediationReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName("FenceAgentsRemediation"),
-		Scheme:     mgr.GetScheme(),
-		Executor:   executer,
-		AgentsList: agentList,
+		Client:          mgr.GetClient(),
+		Log:             ctrl.Log.WithName("controllers").WithName("FenceAgentsRemediation"),
+		Scheme:          mgr.GetScheme(),
+		Executor:        executer,
+		AgentsWhiteList: agentsList,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "FenceAgentsRemediation")
 		os.Exit(1)
@@ -157,9 +157,9 @@ func printVersion() {
 	setupLog.Info(fmt.Sprintf("Build Date: %s", version.BuildDate))
 }
 
-func printSupportedFenceAgents(agentList []string) {
-	setupLog.Info(fmt.Sprintf("Fence agents: %d", len(agentList)))
-	setupLog.Info(fmt.Sprintf("Available agents: %s", strings.Join(agentList, " ")))
+func printSupportedFenceAgents(agentsList []string) {
+	setupLog.Info(fmt.Sprintf("Fence agents: %d", len(agentsList)))
+	setupLog.Info(fmt.Sprintf("Available agents: %s", strings.Join(agentsList, " ")))
 }
 
 // getFenceAgents check if the file exists, read it, and then remove redundant prefix

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -19,6 +19,7 @@ const (
 	RemediationFinishedNodeNotFoundConditionMessage = "FAR CR name doesn't match a node name"
 	RemediationInterruptedByNHCConditionMessage     = "Node Healthcheck timeout annotation has been set"
 	RemediationStartedConditionMessage              = "FAR CR was found, its name matches one of the cluster nodes, and a finalizer was set to the CR"
+	FenceAgentNotSupportedConditionMessage          = "Not supported fence agent"
 	FenceAgentSucceededConditionMessage             = "FAR taint was added and the fence agent command has been created and executed successfully"
 	FenceAgentFailedConditionMessage                = "Fence agent command has failed"
 	FenceAgentTimedOutConditionMessage              = "Time out occurred while executing the Fence agent command"
@@ -35,6 +36,8 @@ const (
 	RemediationInterruptedByNHC ConditionsChangeReason = "RemediationInterruptedByNHC"
 	// RemediationStarted - CR was found, its name matches a node, and a finalizer was set
 	RemediationStarted ConditionsChangeReason = "RemediationStarted"
+	// FenceAgentNotSupported -
+	FenceAgentNotSupported ConditionsChangeReason = "FenceAgentNotSupported"
 	// FenceAgentSucceeded - FAR taint was added, fence agent command has been created and executed successfully
 	FenceAgentSucceeded ConditionsChangeReason = "FenceAgentSucceeded"
 	// FenceAgentFailed - Fence agent command has been created but failed to execute
@@ -62,7 +65,7 @@ func UpdateConditions(reason ConditionsChangeReason, far *v1alpha1.FenceAgentsRe
 	// - FenceAgentSucceeded, FenceAgentFailed and FenceAgentTimedOut can only happen after RemediationStarted happened
 	// - RemediationFinishedSuccessfully can only happen after FenceAgentSucceeded happened
 	switch reason {
-	case RemediationFinishedNodeNotFound, RemediationInterruptedByNHC, FenceAgentFailed, FenceAgentTimedOut:
+	case RemediationFinishedNodeNotFound, RemediationInterruptedByNHC, FenceAgentNotSupported, FenceAgentFailed, FenceAgentTimedOut:
 		processingConditionStatus = metav1.ConditionFalse
 		fenceAgentActionSucceededConditionStatus = metav1.ConditionFalse
 		succeededConditionStatus = metav1.ConditionFalse
@@ -72,6 +75,8 @@ func UpdateConditions(reason ConditionsChangeReason, far *v1alpha1.FenceAgentsRe
 			conditionMessage = RemediationFinishedNodeNotFoundConditionMessage
 		case RemediationInterruptedByNHC:
 			conditionMessage = RemediationInterruptedByNHCConditionMessage
+		case FenceAgentNotSupported:
+			conditionMessage = FenceAgentNotSupportedConditionMessage
 		case FenceAgentFailed:
 			conditionMessage = FenceAgentFailedConditionMessage
 		case FenceAgentTimedOut:


### PR DESCRIPTION
Verify and restrict far CRs to specific (and available) agents that exist in the container/pod.

1. Print on start-up the amount and list of available agents.
2. Validate CR agent name with the available agents.
3. Add new unit-test for creating CR with unknown agent name

[ECOPROJECT-1753](https://issues.redhat.com//browse/ECOPROJECT-1753)