### PR TITLE
Improve Logs from Updating Conditions

### DIFF
--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -124,7 +124,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 	}
 	if !valid {
 		r.Log.Error(err, "Didn't find a node matching the CR's name", "CR's Name", req.Name)
-		err := utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
+		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
 		return emptyResult, err
 	}
 
@@ -132,7 +132,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 	if isTimedOutByNHC(far) {
 		r.Log.Info("FAR remediation was stopped by Node Healthcheck Operator")
 		r.Executor.Remove(far.GetUID())
-		err := utils.UpdateConditions(utils.RemediationInterruptedByNHC, far, r.Log)
+		utils.UpdateConditions(utils.RemediationInterruptedByNHC, far, r.Log)
 		return emptyResult, err
 	}
 
@@ -144,9 +144,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		}
 		r.Log.Info("Finalizer was added", "CR Name", req.Name)
 
-		if err := utils.UpdateConditions(utils.RemediationStarted, far, r.Log); err != nil {
-			return emptyResult, err
-		}
+		utils.UpdateConditions(utils.RemediationStarted, far, r.Log)
 		return requeueImmediately, nil
 	} else if controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) && !far.ObjectMeta.DeletionTimestamp.IsZero() {
 		// Delete CR only when a finalizer and DeletionTimestamp are set
@@ -212,9 +210,7 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 			r.Log.Error(err, "Manual workload deletion has failed", "CR's Name", req.Name)
 			return emptyResult, err
 		}
-		if err := utils.UpdateConditions(utils.RemediationFinishedSuccessfully, far, r.Log); err != nil {
-			return emptyResult, err
-		}
+		utils.UpdateConditions(utils.RemediationFinishedSuccessfully, far, r.Log)
 
 		r.Executor.Remove(far.GetUID())
 		r.Log.Info("FenceAgentsRemediation CR has completed to remediate the node", "Node Name", req.Name)

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -246,10 +246,6 @@ func (e *Executer) updateStatus(ctx context.Context, far *v1alpha1.FenceAgentsRe
 		reason = utils.FenceAgentFailed
 	}
 
-	err = utils.UpdateConditions(reason, far, e.log)
-	if err != nil {
-		e.log.Error(err, "failed to update conditions", "FAR uid", far.UID)
-		return err
-	}
+	utils.UpdateConditions(reason, far, e.log)
 	return e.Status().Update(ctx, far)
 }

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -137,7 +137,7 @@ func UpdateConditions(reason ConditionsChangeReason, far *v1alpha1.FenceAgentsRe
 		now := metav1.Now()
 		far.Status.LastUpdateTime = &now
 	}
-	log.Info("Updating Status Condition", "processingConditionStatus", processingConditionStatus, "fenceAgentActionSucceededConditionStatus", fenceAgentActionSucceededConditionStatus, "succeededConditionStatus", succeededConditionStatus, "reason", string(reason), "LastUpdateTime", far.Status.LastUpdateTime)
+	log.Info("Updating Status Condition", "processingConditionStatus", processingConditionStatus, "fenceAgentActionSucceededConditionStatus", fenceAgentActionSucceededConditionStatus, "succeededConditionStatus", succeededConditionStatus, "reason", string(reason), "LastUpdateTime", far.Status.LastUpdateTime.Time)
 
 	return
 }


### PR DESCRIPTION
The `UpdateConditions` function has an error only when an unknown agent has been found. Thus, there is no need to return and check it from reconcile, since it is not an error from trying to update it. 
FAR can simply log an informative error when it was called when unknown ConditionsChangeReason.
Moreover, the lastTrinsitionTime print is more human friendly