### PR TITLE
[WIP] Minimize FAR Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,16 +30,16 @@ COPY .git/ .git/
 # Build
 RUN ./hack/build.sh
 
-FROM quay.io/centos/centos:stream8
+FROM debian:stable-slim
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
 # Add Fence Agents and fence-agents-aws packages
-RUN dnf install -y dnf-plugins-core \
-    && dnf config-manager --set-enabled ha \
-    && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm fence-agents-gce \
-    && dnf clean all -y
+RUN apt-get update -y \
+    && apt-get install -y ipmitool fence-agents --no-install-recommends \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Building FAR using `debian-slim` for smaller image
Using half the previous image size is better for downloading the image and minimizing any potential risks from running a larger image (with some redundant files).

TODO: Update [e2e test environment](https://github.com/openshift/release/blob/master/ci-operator/config/medik8s/fence-agents-remediation/medik8s-fence-agents-remediation-main__4.15.yaml#L7) to build FAR using debian-slim and not CentOS

[ECOPROJECT-1757](https://issues.redhat.com//browse/ECOPROJECT-1757)