### PR TITLE
Initialize Event Recorder for executer

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -48,13 +48,12 @@ import (
 const defaultNamespace = "default"
 
 var (
-	k8sClient             client.Client
-	k8sManager            manager.Manager
-	testEnv               *envtest.Environment
-	ctx                   context.Context
-	cancel                context.CancelFunc
-	fakeReconcileRecorder *record.FakeRecorder
-	fakeExecRecorder      *record.FakeRecorder
+	k8sClient    client.Client
+	k8sManager   manager.Manager
+	testEnv      *envtest.Environment
+	ctx          context.Context
+	cancel       context.CancelFunc
+	fakeRecorder *record.FakeRecorder
 
 	plogs *peekLogger
 
@@ -137,17 +136,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	var executor *cli.Executer
-	executor, fakeExecRecorder, _ = cli.NewFakeExecuter(k8sClient, controlledRun)
-
+	fakeRecorder = record.NewFakeRecorder(30)
+	executor := cli.NewFakeExecuter(k8sClient, controlledRun, fakeRecorder)
 	os.Setenv("DEPLOYMENT_NAMESPACE", defaultNamespace)
 
-	fakeReconcileRecorder = record.NewFakeRecorder(20)
 	err = (&FenceAgentsRemediationReconciler{
 		Client:   k8sClient,
 		Log:      k8sManager.GetLogger().WithName("test far reconciler"),
 		Scheme:   k8sManager.GetScheme(),
-		Recorder: fakeReconcileRecorder,
+		Recorder: fakeRecorder,
 		Executor: executor,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	executer, err := cli.NewExecuter(mgr.GetClient())
+	executer, err := cli.NewExecuter(mgr.GetClient(), mgr.GetEventRecorderFor(operatorName+"-executer"))
 	if err != nil {
 		setupLog.Error(err, "unable to create executer")
 		os.Exit(1)

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -49,7 +49,7 @@ type Executer struct {
 type runnerFunc func(ctx context.Context, command []string) (string, string, error)
 
 // NewExecuter builds the Executer
-func NewExecuter(client client.Client) (*Executer, error) {
+func NewExecuter(client client.Client, newRecorder record.EventRecorder) (*Executer, error) {
 	logger := ctrl.Log.WithName("executer")
 
 	return &Executer{
@@ -57,6 +57,7 @@ func NewExecuter(client client.Client) (*Executer, error) {
 		log:      logger,
 		routines: make(map[types.UID]*routine),
 		runner:   run,
+		recorder: newRecorder,
 	}, nil
 }
 

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -185,7 +185,6 @@ func (e *Executer) updateStatusWithRetry(ctx context.Context, uid types.UID, fen
 			}
 
 			e.log.Info("status updated", "FAR uid", uid)
-			commonEvents.NormalEvent(e.recorder, far, utils.EventReasonFenceAgentSucceeded, utils.EventMessageFenceAgentSucceeded)
 			return true, nil
 		})
 	return err
@@ -246,6 +245,7 @@ func (e *Executer) updateStatus(ctx context.Context, far *v1alpha1.FenceAgentsRe
 
 	if err == nil {
 		reason = utils.FenceAgentSucceeded
+		commonEvents.NormalEvent(e.recorder, far, utils.EventReasonFenceAgentSucceeded, utils.EventMessageFenceAgentSucceeded)
 	} else if wait.Interrupted(err) {
 		reason = utils.FenceAgentTimedOut
 	} else {

--- a/pkg/cli/fake.go
+++ b/pkg/cli/fake.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewExecuter builds an Executer with configurable runnerFunc for testing
-func NewFakeExecuter(client client.Client, fn runnerFunc) (*Executer, error) {
+func NewFakeExecuter(client client.Client, fn runnerFunc) (*Executer, *record.FakeRecorder, error) {
 	logger := ctrl.Log.WithName("fakeExecuter")
 	fakeRecorder := record.NewFakeRecorder(10)
 
@@ -18,5 +18,5 @@ func NewFakeExecuter(client client.Client, fn runnerFunc) (*Executer, error) {
 		routines: make(map[types.UID]*routine),
 		runner:   fn,
 		recorder: fakeRecorder,
-	}, nil
+	}, fakeRecorder, nil
 }

--- a/pkg/cli/fake.go
+++ b/pkg/cli/fake.go
@@ -7,16 +7,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewExecuter builds an Executer with configurable runnerFunc for testing
-func NewFakeExecuter(client client.Client, fn runnerFunc) (*Executer, *record.FakeRecorder, error) {
+// NewFakeExecuter builds an Executer with configurable runnerFunc for testing
+func NewFakeExecuter(client client.Client, fn runnerFunc, fakeRecorder *record.FakeRecorder) *Executer {
 	logger := ctrl.Log.WithName("fakeExecuter")
-	fakeRecorder := record.NewFakeRecorder(10)
-
 	return &Executer{
 		Client:   client,
 		log:      logger,
 		routines: make(map[types.UID]*routine),
 		runner:   fn,
 		recorder: fakeRecorder,
-	}, fakeRecorder, nil
+	}
 }


### PR DESCRIPTION
- Initialization was missing, and [`e.recorder`](https://github.com/medik8s/fence-agents-remediation/blob/main/pkg/cli/cliexecuter.go#L187) was nil.
- Fix unit-tests

Fix [ECOPROJECT-1816](https://issues.redhat.com//browse/ECOPROJECT-1816)