### PR TITLE
[WIP] Support off action

### DIFF
--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -48,10 +48,12 @@ const (
 	// errors
 	errorMissingParams     = "nodeParameters or sharedParameters or both are missing, and they cannot be empty"
 	errorMissingNodeParams = "node parameter is required, and cannot be empty"
+	errorUnsupportedAction = "FAR doesn't support any other action than reboot and off"
 
-	SuccessFAResponse    = "Success: Rebooted"
-	parameterActionName  = "--action"
-	parameterActionValue = "reboot"
+	SuccessFAResponse          = "Success: Rebooted"
+	parameterActionName        = "--action"
+	parameterRebootActionValue = "reboot"
+	parameterOffActionValue    = "off"
 )
 
 // FenceAgentsRemediationReconciler reconciles a FenceAgentsRemediation object
@@ -279,9 +281,10 @@ func (r *FenceAgentsRemediationReconciler) updateStatus(ctx context.Context, far
 }
 
 // buildFenceAgentParams collects the FAR's parameters for the node based on FAR CR, and if the CR is missing parameters
-// or the CR's name don't match nodeParameter name or it has an action which is different than reboot, then return an error
+// or the CR's name don't match nodeParameter name or it has an action which is different than reboot and off, then return an error
 func buildFenceAgentParams(far *v1alpha1.FenceAgentsRemediation) ([]string, error) {
 	logger := ctrl.Log.WithName("build-fa-parameters")
+	parameterActionValue := parameterRebootActionValue
 	if far.Spec.NodeParameters == nil || far.Spec.SharedParameters == nil {
 		err := errors.New(errorMissingParams)
 		logger.Error(err, "Missing parameters")
@@ -292,11 +295,16 @@ func buildFenceAgentParams(far *v1alpha1.FenceAgentsRemediation) ([]string, erro
 	for paramName, paramVal := range far.Spec.SharedParameters {
 		if paramName != parameterActionName {
 			fenceAgentParams = appendParamToSlice(fenceAgentParams, paramName, paramVal)
-		} else if paramVal != parameterActionValue {
-			// --action attribute was selected but it is different than reboot
-			err := errors.New("FAR doesn't support any other action than reboot")
-			logger.Error(err, "can't build CR with this action attribute", "action", paramVal)
-			return nil, err
+		} else {
+			switch paramVal {
+			case parameterRebootActionValue, parameterOffActionValue:
+				parameterActionValue = paramVal
+			default:
+				// --action attribute was selected but it is different than reboot and off
+				err := errors.New(errorUnsupportedAction)
+				logger.Error(err, "can't build CR with this action attribute", "action", paramVal)
+				return nil, err
+			}
 		}
 	}
 	// if --action attribute was not selected, then its default value is reboot

--- a/controllers/fenceagentsremediation_controller_test.go
+++ b/controllers/fenceagentsremediation_controller_test.go
@@ -99,6 +99,47 @@ var _ = Describe("FAR Controller", func() {
 		})
 
 		Context("buildFenceAgentParams", func() {
+			Context("build fence agent params", func() {
+				baseShareParam := map[v1alpha1.ParameterName]string{
+					"--username": "admin",
+					"--password": "password",
+					"--ip":       "192.168.111.1",
+					"--lanplus":  "",
+				}
+				testCases := []struct {
+					name   string
+					action string
+					expect error
+				}{
+					{"reboot action", "reboot", nil},
+					{"off action", "off", nil},
+					{"unsupported action", "cycle", errors.New(errorUnsupportedAction)},
+				}
+
+				for _, tc := range testCases {
+					When(fmt.Sprintf("FAR includes %s", tc.name), func() {
+						It("should return expected result", func() {
+							shareParam := baseShareParam
+							shareParam["--action"] = tc.action
+							far := getFenceAgentsRemediation(workerNode, fenceAgentIPMI, shareParam, testNodeParam)
+							shareString, err := buildFenceAgentParams(far)
+							if tc.expect == nil {
+								Expect(err).NotTo(HaveOccurred())
+								Expect(shareString).To(ConsistOf([]string{
+									"--lanplus",
+									"--password=password",
+									"--username=admin",
+									fmt.Sprintf("--action=%s", tc.action),
+									"--ip=192.168.111.1",
+									"--ipport=6233"}))
+							} else {
+								Expect(err).To(HaveOccurred())
+								Expect(err).To(Equal(tc.expect))
+							}
+						})
+					})
+				}
+			})
 			When("FAR include different action than reboot", func() {
 				It("should succeed with a warning", func() {
 					invalidValTestFAR := getFenceAgentsRemediation(workerNode, fenceAgentIPMI, invalidShareParam, testNodeParam)


### PR DESCRIPTION
This PR is to support off action.

The following is the FAR workflow with off action:
1. FAR adds NoExecute taint to the failed node
2. FAR powers off the failed node via the Fence Agent
3. FAR deletes workloads in the failed node
4. [User Intervention] Admins turn the failed node on after they check the failed node has been recovered.
5. After the failed node becomes healthy, NHC deletes FenceAgentsRemediation CR, the NoExecute taint in Step 2 is removed, and the node becomes schedulable again

In step 4, if users want to do troubleshooting on the failed node, they need to manually add the proper taints before turning on the failed node. The document pr is tracked in https://issues.redhat.com/browse/ECOPROJECT-1756.

[ECOPROJECT-1471](https://issues.redhat.com/browse/ECOPROJECT-1471)