### PR TITLE
Set Golang version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream8 AS builder
-RUN dnf install -y golang jq git \
+RUN dnf install -y jq git \
     && dnf clean all -y
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,28 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream8 AS builder
-RUN dnf install -y golang git \
+RUN dnf install -y golang jq git \
     && dnf clean all -y
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
+# Copy the Go Modules manifests for detecting Go version
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Ensure correct Go version
-RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
-    go install golang.org/dl/go${GO_VERSION}@latest && \
-    ~/go/bin/go${GO_VERSION} download && \
-    /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go && \
-    go version
+RUN \
+    # get Go version from mod file
+    export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
+    echo ${GO_VERSION} && \
+    # find filename for latest z version from Go download page
+    export GO_FILENAME=$(curl -sL 'https://go.dev/dl/?mode=json&include=all' | jq -r "[.[] | select(.version | startswith(\"go${GO_VERSION}\"))][0].files[] | select(.os == \"linux\" and .arch == \"amd64\") | .filename") && \
+    echo ${GO_FILENAME} && \
+    # download and unpack
+    curl -sL -o go.tar.gz "https://golang.org/dl/${GO_FILENAME}" && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+
+# add Go directory to PATH
+ENV PATH="${PATH}:/usr/local/go/bin"
+RUN go version
 
 # Copy the go source
 COPY main.go main.go


### PR DESCRIPTION
#### Why we need this PR

Fix the way we set the Golang version in the Dockerfile. 
See the below error from [post-submit](https://github.com/medik8s/fence-agents-remediation/blob/main/.github/workflows/post-submit.yaml) job that blocks the container build, of the pushed code (after merging PR or setting new tag), and eventually pushing it to Quay.

> .
> .
> .
> RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk ...
> go: downloading golang.org/dl v0.0.0-20240305174203-2885f567d808
> go: golang.org/dl/go1.21@latest: module golang.org/dl@latest found (v0.0.0-20240305174203-2885f567d808), but does not contain package golang.org/dl/go1.21

It tries to use Golang v1.21 ([latest installed Golang version](https://github.com/medik8s/fence-agents-remediation/blob/main/Dockerfile#L3)) for installing Golang v1.20.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
Directly install a desired Go version instead of first installing what the builder image provides, and then using Golang CLI to get the desired version. It stems from an error we have seen in building the contianer at the [post-submit](https://github.com/medik8s/fence-agents-remediation/blob/main/.github/workflows/post-submit.yaml) job

#### Which issue(s) this PR fixes
No issues, but an error from post-submit job
