### PR TITLE
Manual workflow for tagged versions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -3,22 +3,25 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: write
   pull-requests: read
 
 jobs:
-  push-images:
-    name: Build and push images to quay.io/medik8s
+  push_to_registry:
+    name: Build and push unversioned images to quay.io/medik8s
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
 
       - name: Log in to Quay.io
         uses: docker/login-action@v2
@@ -27,14 +30,8 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
-      - name: Build and push CSV 0.0.1 + latest images for PR merges to main
-        if: ${{ github.ref_type != 'tag' }}
+      - name: Build and push CSV version v0.0.1 with latest images
         run: export IMAGE_REGISTRY=quay.io/medik8s && make container-build-and-push-community
-
-      - name: Build and push versioned CSV and images for tags
-        if: ${{ github.ref_type == 'tag' }}
-        # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-and-push-community
 
       - name: Create release with manifests
         if: ${{ github.ref_type == 'tag' }}

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,110 @@
-name: Release bundles
+name: Release
 on:
   workflow_dispatch:
-    inputs:
-        version:
-          description: "The version to release, without the leading `v`"
-          required: true
-          type: string
-        previous_version:
-          description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
-          required: true
-          type: string
-        community:
-          description: "The community to release the bundle to"
-          required: true
-          type: choice
-          default: "K8S"
-          options:
-            - K8S
-            - OKD
+   inputs:
+     operation:
+       description: "The operation to perform."
+       required: true
+       type: choice
+       default: "build_and_push_images"
+       options:
+         - build_and_push_images
+         - create_okd_release_pr
+         - create_k8s_release_pr
+     version:
+       description: "The version to release, without the leading `v`"
+       required: true
+     previous_version:
+       description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
+       required: false
+     skip_range_lower:
+       description: "Lower bound for the skipRange field in the CSV, should be set to the oldest supported version, without the leading `v`"
+       required: true
+     ocp_version:
+       description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
+       required: false
+
+permissions:
+  contents: write
 
 jobs:
-  make_k8s_community_bundle:
-    if: inputs.community == 'K8S'
+  push_to_registry:
+    if: ${{ inputs.operation == 'build_and_push_images' }}
+    name: Build and push images to quay.io/medik8s
+    runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ inputs.version }}
+      #PREVIOUS_VERSION: ${{ inputs.previous_version }}
+      SKIP_RANGE_LOWER: ${{ inputs.skip_range_lower }}
+      OCP_VERSION: ${{ inputs.ocp_version }}
+    steps:
+      - name: Log inputs
+        run: |
+          echo "Building version: ${VERSION},"
+          #echo "which replaces version: ${PREVIOUS_VERSION}."
+          echo "Lower skip range bound: ${SKIP_RANGE_LOWER}."
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+
+      - name: Build and push versioned CSV and images
+        run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION SKIP_RANGE_LOWER=$SKIP_RANGE_LOWER make container-build-k8s container-push
+
+      - name: Create release with manifests
+        if: ${{ github.ref_type == 'tag' }}
+        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          body: |
+            # Fence Agents Remediation ${{ github.ref_name }}
+            
+            ## Notable Changes
+            
+            * TODO
+            
+            ## Release Artifacts
+            
+            ### Images
+            * Operator: quay.io/medik8s/fence-agents-remediation-operator:${{ github.ref_name }}
+            * Bundle: quay.io/medik8s/fence-agents-remediation-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/medik8s/fence-agents-remediation-operator-catalog:${{ github.ref_name }}
+            
+            ### Source code and OLM manifests
+            Please find the source code and the OLM manifests in the `Assets` section below.
+          gzip: folders
+          files: >
+            Manifests:bundle/
+  create_k8s_release_pr:
+    if: inputs.operation == 'create_k8s_release_pr'
     uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
-      previous_version: ${{ inputs.previous_version }}
-      community: ${{ inputs.community }}
+      community: 'K8S'
       make_targets: "bundle-community-k8s"
-  make_okd_community_bundle:
-    if: inputs.community == 'OKD'
+  create_okd_release_pr:
+    if: inputs.operation == 'create_okd_release_pr'
     uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
       previous_version: ${{ inputs.previous_version }}
-      community: ${{ inputs.community }}
+      ocp_version: ${{ inputs.ocp_version }}
+      community: 'OKD'
       make_targets: "bundle-community-rh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,17 +41,17 @@ jobs:
           echo "OCP version (optional): ${OCP_VERSION}."
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ on:
      previous_version:
        description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
        required: false
-     skip_range_lower:
-       description: "Lower bound for the skipRange field in the CSV, should be set to the oldest supported version, without the leading `v`"
-       required: true
      ocp_version:
        description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
        required: false
@@ -34,15 +31,14 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       VERSION: ${{ inputs.version }}
-      #PREVIOUS_VERSION: ${{ inputs.previous_version }}
-      SKIP_RANGE_LOWER: ${{ inputs.skip_range_lower }}
+      PREVIOUS_VERSION: ${{ inputs.previous_version }}
       OCP_VERSION: ${{ inputs.ocp_version }}
     steps:
       - name: Log inputs
         run: |
           echo "Building version: ${VERSION},"
-          #echo "which replaces version: ${PREVIOUS_VERSION}."
-          echo "Lower skip range bound: ${SKIP_RANGE_LOWER}."
+          echo "replaces version (optional): ${PREVIOUS_VERSION},"
+          echo "OCP version (optional): ${OCP_VERSION}."
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           registry: quay.io
 
       - name: Build and push versioned CSV and images
-        run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION SKIP_RANGE_LOWER=$SKIP_RANGE_LOWER make container-build-k8s container-push
+        run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION make container-build-and-push-community
 
       - name: Create release with manifests
         if: ${{ github.ref_type == 'tag' }}

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,9 @@ add-replaces-field: ## Add replaces field to the CSV
 		if [ $(PREVIOUS_VERSION) == $(DEFAULT_VERSION) ]; then \
 			echo "Error: PREVIOUS_VERSION must be set for versioned builds"; \
 			exit 1; \
+		elif [ $(shell ./hack/semver_cmp.sh $(VERSION) $(PREVIOUS_VERSION)) != 1 ]; then \
+			echo "Error: VERSION ($(VERSION)) must be greater than PREVIOUS_VERSION ($(PREVIOUS_VERSION))"; \
+			exit 1; \
 		else \
 		  	# preferring sed here, in order to have "replaces" near "version" \
 			sed -r -i "/  version: $(VERSION)/ a\  replaces: $(OPERATOR_NAME).v$(PREVIOUS_VERSION)" ${BUNDLE_CSV}; \

--- a/Makefile
+++ b/Makefile
@@ -253,19 +253,24 @@ export ICON_BASE64 ?= ${DEFAULT_ICON_BASE64}
 export BUNDLE_CSV ?="./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml"
 
 .PHONY: bundle-update
-bundle-update: verify-previous-version ## Update CSV fields and validate the bundle directory
+bundle-update: ## Update CSV fields and validate the bundle directory
 	sed -r -i "s|containerImage: .*|containerImage: $(IMG)|;" ${BUNDLE_CSV}
 	sed -r -i "s|createdAt: .*|createdAt: `date '+%Y-%m-%d %T'`|;" ${BUNDLE_CSV}
-	sed -r -i "s|replaces: .*|replaces: $(OPERATOR_NAME).v${PREVIOUS_VERSION}|;" ${BUNDLE_CSV}
 	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ${BUNDLE_CSV}
 	$(MAKE) bundle-validate
 
-.PHONY: verify-previous-version
-verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
-	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
-  			echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
-    		exit 1; \
-    fi
+.PHONY: add-replaces-field
+add-replaces-field: ## Add replaces field to the CSV
+	# add replaces field when building versioned bundle
+	@if [ $(VERSION) != $(DEFAULT_VERSION) ]; then \
+		if [ $(PREVIOUS_VERSION) == $(DEFAULT_VERSION) ]; then \
+			echo "Error: PREVIOUS_VERSION must be set for versioned builds"; \
+			exit 1; \
+		else \
+		  	# preferring sed here, in order to have "replaces" near "version" \
+			sed -r -i "/  version: $(VERSION)/ a\  replaces: $(OPERATOR_NAME).v$(PREVIOUS_VERSION)" ${BUNDLE_CSV}; \
+		fi \
+	fi
 
 .PHONY: bundle-reset-date
 bundle-reset-date: ## Reset bundle's createdAt
@@ -275,8 +280,9 @@ bundle-reset-date: ## Reset bundle's createdAt
 bundle-community-k8s: bundle-community ## Generate bundle manifests and metadata customized to Red Hat community release
 
 .PHONY: bundle-community-rh
-bundle-community-rh: bundle-community ## Generate bundle manifests and metadata customized to Red Hat community release
+bundle-community-rh: bundle-community  ## Generate bundle manifests and metadata customized to Red Hat community release
 	echo -e "\n  # Annotations for OCP\n  com.redhat.openshift.versions: \"v${OCP_VERSION}\"" >> bundle/metadata/annotations.yaml
+	$(MAKE) add-replaces-field
 
 .PHONY: bundle-community
 bundle-community: bundle ## Update displayName field in the bundle's CSV

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -159,7 +159,7 @@ spec:
     - Speed - FAR is rapid since it can reboot a node and receive an acknowledgment from the API call while other remediators might need to wait a safe time till they can expect the node to be rebooted.
     - Diversity - FAR includes several fence agents from a large known set of upstream fencing agents for bare metal servers, virtual machines, cloud platforms, etc.
     - Adjustability - FAR allows to set up different parameters for running the API call that remediates the node.
-  displayName: Fence Agents Remediation Operator - Community Edition
+  displayName: Fence Agents Remediation Operator
   icon:
   - base64data: base64EncodedIcon
     mediatype: image/png

--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -159,7 +159,7 @@ spec:
     - Speed - FAR is rapid since it can reboot a node and receive an acknowledgment from the API call while other remediators might need to wait a safe time till they can expect the node to be rebooted.
     - Diversity - FAR includes several fence agents from a large known set of upstream fencing agents for bare metal servers, virtual machines, cloud platforms, etc.
     - Adjustability - FAR allows to set up different parameters for running the API call that remediates the node.
-  displayName: Fence Agents Remediation Operator
+  displayName: Fence Agents Remediation Operator - Community Edition
   icon:
   - base64data: base64EncodedIcon
     mediatype: image/png
@@ -407,7 +407,6 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  replaces: fence-agents-remediation.v0.0.1
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/fence-agents-remediation.clusterserviceversion.yaml
@@ -156,5 +156,4 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
-  replaces: fence-agents-remediation.v0.0.1
   version: 0.0.0

--- a/hack/semver_cmp.sh
+++ b/hack/semver_cmp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# -*- coding: UTF-8 -*-
+## Compare two semantic version numbers.
+## Usage:
+## - is_version_greater_or_equal.sh 1.2.3 1.2.4  ## -1
+## - is_version_greater_or_equal.sh 1.2.4 1.2.4  ## 0
+## - is_version_greater_or_equal.sh 1.2.5 1.2.4  ## +1
+
+if [ "$#" -ne 2 ]; then
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+if [ "$1" = "$2" ]; then
+    echo 0
+else
+    # sort the input and check if it is sorted (quietly).
+    # `sort` will exit successfully if the given file is already sorted, and exit with status 1 otherwise.
+    # Since we already excluded that the two versions are equal, if the input is sorted,
+    # it means the first argument is less than the second one.
+    # https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html#sort-invocation
+    printf "%s\n%s\n" "$1" "$2" | sort --version-sort --check=quiet && echo -1 || echo 1
+fi


### PR DESCRIPTION
#### Why we need this PR

FAR CI uses the post-release workflow for building and pushing versioned bundle images, however, the workflow cannot guess the right PREVIOUS_VERSION (when it is necessary) and it would publish manifests with wrong value of the `.spec.replaces` field.

#### Changes made

- Move build and push images job from the `post-release` to the `release` workflow, which supports manual inputs such has PREVIOUS_VERSION
- Integrated the `release` workflow with the latest version of Medik8s shared workflow to build and push community bundles
- Set `spec.replaces` field only in OKD bundle


#### Test plan
Tested locally with nektos/act
