### PR TITLE
Test Scorecard testing in Makefile

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -20,12 +20,12 @@ jobs: # jobs to run
     runs-on: ubuntu-22.04 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Go # https://github.com/actions/setup-go/blob/main/action.yml
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with: 
         go-version-file: 'go.mod' 
         cache-dependency-path: 'go.sum' 
@@ -35,3 +35,40 @@ jobs: # jobs to run
 
     - name: Build Images
       run: make container-build-community
+
+  scorecard-k8s:
+    name: Test Scorecard Tests # https://sdk.operatorframework.io/docs/testing-operators/scorecard/
+    runs-on: ubuntu-22.04
+    env:
+      # see https://github.com/kubernetes-sigs/kind/tags
+      KIND_VERSION: v0.22.0
+      # see https://hub.docker.com/r/kindest/node/tags for available versions!
+      K8S_VERSION: v1.27.11
+      FAR_VERSION: 0.3.0
+      FAR_PREVIOUS_VERSION: 0.2.1
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Start kind cluster
+      uses: container-tools/kind-action@v2
+      with:
+        version: ${{env.KIND_VERSION}}
+        config: ./hack/kind-scorecard-config.yaml
+        node_image: kindest/node:${{env.K8S_VERSION}}
+        kubectl_version: ${{env.K8S_VERSION}}
+        registry: true
+
+    - name: Cluster info
+      run: |
+        kubectl version -o=yaml
+        kubectl cluster-info
+        kubectl get nodes -o=wide
+    - name: Build bundle-community
+      run: PREVIOUS_VERSION=${{env.FAR_PREVIOUS_VERSION}} VERSION=${{env.FAR_VERSION}} make bundle-community
+
+    - name: Run scorecard tests
+      run: OPERATOR_NAMESPACE=default make test-scorecard

--- a/Makefile
+++ b/Makefile
@@ -466,8 +466,6 @@ test-e2e: ginkgo ## Run end to end (E2E) tests
 .PHONY: bundle-reset
 bundle-reset:
 	VERSION=0.0.1 $(MAKE) manifests bundle
-	# empty creation date
-	sed -r -i "s|createdAt: .*|createdAt: \"\"|;" ${BUNDLE_CSV}
 
 .PHONY: full-gen
-full-gen:  go-verify manifests  generate manifests fmt bundle fix-imports bundle-reset ## generates all automatically generated content
+full-gen: go-verify manifests  generate manifests fmt bundle fix-imports bundle-reset ## generates all automatically generated content

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,10 @@ catalog-push: ## Push a catalog image.
 verify-unchanged: ## Verify there are no un-committed changes
 	./hack/verify-unchanged.sh
 
+.PHONY: test-scorecard
+test-scorecard: operator-sdk ## Run Scorecard testing for the bundle directory on OPERATOR_NAMESPACE
+	$(OPERATOR_SDK) scorecard ./bundle -n $(OPERATOR_NAMESPACE)
+
 .PHONY: container-build 
 container-build: docker-build bundle-build ## Build containers
 

--- a/hack/kind-scorecard-config.yaml
+++ b/hack/kind-scorecard-config.yaml
@@ -1,0 +1,5 @@
+# One control plane node cluster config for k8s e2e test in github workflow!
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane


### PR DESCRIPTION
Add [Scorecard testing](https://sdk.operatorframework.io/docs/testing-operators/scorecard/) for FAR on GitHub CI and a Kubernetes [kind cluster](https://kind.sigs.k8s.io/).

#### Why we need this PR
Scorecard testing extends our CI for bundle verification.

#### Changes made

- Makefile target for running the scorecard test
- Kind config
- New GitHub CI which uses the new target and kind config to set a Kubernetes cluster,  and to run the scorecard testing (it initiates config maps and pods for the tests)
- FIx for `bundle-reset` target

#### Which issue(s) this PR fixes
Similar PR to [NMO #129 ](https://github.com/medik8s/node-maintenance-operator/pull/129)