### PR TITLE
Check stderr when running agent

### DIFF
--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -127,7 +127,7 @@ func (e *Executer) runWithRetry(ctx context.Context, uid types.UID, command []st
 			ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 			stdout, stderr, faErr = e.runner(ctxWithTimeout, command)
-			if faErr == nil {
+			if faErr == nil && stderr == "" {
 				e.log.Info("command completed", "uid", uid, "response", stdout, "errMessage", stderr, "err", faErr)
 				return true, nil
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
Considering a successful command execution when the return value is zero, no error, and stderr is empty as well.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Include a check for stderr being empty when considering a successful agent execution.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->
Fixes (somehow) [ECOPROJECT-1938](https://issues.redhat.com//browse/ECOPROJECT-1938)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
