### PR TITLE
Fix release workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
         run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION make container-build-and-push-community
 
       - name: Create release with manifests
-        if: ${{ github.ref_type == 'tag' }}
         # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
         uses: meeDamian/github-release@2.0
         with:


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

Currently, the "Create release with manifests" step in the release CI Job is wrongly conditioned under a specific value of github.ref_type ('tag').
This is a leftover of the recent rework and prevent the relece CI to publish the release manifest on GitHub.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
Remove the condition from "Create release with manifests" step

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
This change can be tested only once it is merged, unfortunately.
