### PR TITLE
Update to CentOS Stream9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/centos/centos:stream8 AS builder
+FROM quay.io/centos/centos:stream9 AS builder
 RUN dnf install -y jq git \
     && dnf clean all -y
 
@@ -39,15 +39,14 @@ COPY .git/ .git/
 # Build
 RUN ./hack/build.sh
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
 # Add Fence Agents and fence-agents-aws packages
 RUN dnf install -y dnf-plugins-core \
-    && dnf config-manager --set-enabled ha \
-    && dnf install -y fence-agents-all fence-agents-aws fence-agents-azure-arm fence-agents-gce \
+    && dnf --enablerepo=highavailability install -y fence-agents-all fence-agents-aws fence-agents-azure-arm fence-agents-gce \
     && dnf clean all -y
 
 USER 65532:65532


### PR DESCRIPTION
#### Why we need this PR
Container build fails because of invalid yum repo config.

#### Changes made
Update to CentOS Stream9, Stream8 is EOL
