### PR TITLE
[DO NOT MERGE] Increase timeout to test e2e failures on OCPs

### DIFF
--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -38,10 +38,9 @@ const (
 
 	//TODO: try to minimize timeout
 	// eventually parameters
-	timeoutLogs        = "3m0s"
-	timeoutTaint       = "2s"   // Timeout for checking the FAR taint
-	timeoutReboot      = "6m0s" // fencing with fence_aws should be completed within 6 minutes
-	timeoutAfterReboot = "5s"   // Timeout for verifying steps  after the node has been rebooted
+	timeoutTaint       = "2s"    // Timeout for checking the FAR taint
+	timeoutReboot      = "12m0s" // fencing with fence_aws should be completed within 6 minutes
+	timeoutAfterReboot = "5s"    // Timeout for verifying steps  after the node has been rebooted
 	pollTaint          = "100ms"
 	pollReboot         = "1s"
 	pollAfterReboot    = "250ms"


### PR DESCRIPTION
DO NOT MERGE for now

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

#### Changes made
<!-- Outline the specific changes made in this merge request. -->


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
