### PR TITLE
Remediate Ready Worker Node in E2E

### DIFF
--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -317,7 +317,7 @@ func createFAR(nodeName string, agent string, sharedParameters map[v1alpha1.Para
 			SharedParameters:    sharedParameters,
 			NodeParameters:      nodeParameters,
 			RemediationStrategy: strategy,
-			RetryCount:          5,
+			RetryCount:          10,
 			RetryInterval:       metav1.Duration{Duration: 20 * time.Second},
 			Timeout:             metav1.Duration{Duration: 60 * time.Second},
 		},

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -108,6 +108,10 @@ var _ = Describe("FAR E2e", func() {
 			if availableWorkerNodes == nil {
 				availableWorkerNodes = getReadyWorkerNodes()
 			}
+			if len(availableWorkerNodes.Items) < 1 {
+				Fail("There isn't an available (and Ready) worker node in the cluster")
+			}
+
 			selectedNode = pickRemediatedNode(availableWorkerNodes)
 			nodeName = selectedNode.Name
 			printNodeDetails(selectedNode, nodeIdentifierPrefix, testNodeParam)
@@ -269,18 +273,12 @@ func getReadyWorkerNodes() *corev1.NodeList {
 			}
 		}
 	}
-	if len(readyWorkerNodes.Items) < 1 {
-		Fail("There isn't an available (and ready) worker node in the cluster")
-	}
 	return readyWorkerNodes
 }
 
 // pickRemediatedNode randomly returns a next remediated node from the current available nodes,
 // and then the node is removed from the list of available nodes
 func pickRemediatedNode(availableNodes *corev1.NodeList) *corev1.Node {
-	if len(availableNodes.Items) < 1 {
-		Fail("There isn't an available (and ready) worker node in the cluster")
-	}
 	// Generate a random seed based on the current time
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	// Randomly select a worker node

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -270,7 +270,7 @@ func getReadyWorkerNodes() *corev1.NodeList {
 		}
 	}
 	if len(readyWorkerNodes.Items) < 1 {
-		Skip("There isn't an available (and ready) worker node in the cluster")
+		Fail("There isn't an available (and ready) worker node in the cluster")
 	}
 	return readyWorkerNodes
 }
@@ -279,7 +279,7 @@ func getReadyWorkerNodes() *corev1.NodeList {
 // and then the node is removed from the list of available nodes
 func pickRemediatedNode(availableNodes *corev1.NodeList) *corev1.Node {
 	if len(availableNodes.Items) < 1 {
-		Skip("There isn't an available (and ready) worker node in the cluster")
+		Fail("There isn't an available (and ready) worker node in the cluster")
 	}
 	// Generate a random seed based on the current time
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -193,7 +193,7 @@ func GetPod(nodeName, containerName string) *corev1.Pod {
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      v1alpha1.FARNoExecuteTaintKey,
-					Operator: corev1.TolerationOpEqual,
+					Operator: corev1.TolerationOpExists,
 					Effect:   corev1.TaintEffectNoExecute,
 				},
 				{


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

1. Fix a trailing error when a node becomes unresponsive from the `resourceDeletion` strategy and it is selected for remediation for `outOfService` strategy. Then there is a failure of getting the node boot time in the BeforeEach prior to CR creation https://github.com/medik8s/fence-agents-remediation/blob/main/test/e2e/far_e2e_test.go#L114

```
  [FAILED] failed to get boot time of the node
  Unexpected error:
      <wait.errInterrupted>: 
      timed out waiting for the condition
      {
          cause: <*errors.errorString | 0xc0003cd250>{
              s: "timed out waiting for the condition",
          },
      }
  occurred
```
2. Reboot doesn't succeed on the second node remediation (per strategy), as it can't get the boot time of the node https://github.com/medik8s/fence-agents-remediation/blob/main/test/e2e/far_e2e_test.go#L430 passing a timeout.

```
Timeout for node reboot has passed, even though FAR CR has been created 
The function passed to Eventually returned the following error: <wait.errInterrupted>: timed out waiting for the condition { cause: <*errors.errorString | 0xc0003cd250> { s: "timed out waiting for the condition", }, }
```
3. The tested pods for checking the boot time have been evicted due to [FAR remediation taint](https://github.com/medik8s/fence-agents-remediation/blob/main/api/v1alpha1/fenceagentsremediation_types.go#L30
), while they should tolerate it. 

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

1. Improve the function `getAvailableWorkerNodes` to `getReadyWorkerNodes` by getting a list of all the ready worker nodes. Otherwise, we will try to remediate the node and fail to fetch its boot time at BeforeEach. 
2. Function `getNodeRoleFromMachine` will add the node role to the list of nodes before every e2e test
3. Fix listing machines with no associated node - too long and messy return message.
4. Extend RetryCount for (AWS) agent.
5. Move cluster information from BeforeEach to an independent test, and skip subsequent tests on failure.
6. Tested pods toleration should use the [Exist operator over Equal](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts) as the toleration value is irrelevant

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

[ECOPROJECT-2337](https://issues.redhat.com//browse/ECOPROJECT-2337)
#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
