### PR TITLE
Modify FAR Supported Agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,12 +44,12 @@ FROM quay.io/centos/centos:stream9
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
-# Add Fence Agents and fence-agents-aws packages
+# Add many Fence Agents packages
 RUN dnf install -y dnf-plugins-core \
-    && dnf --enablerepo=highavailability install -y fence-agents-amt-ws fence-agents-apc-snmp fence-agents-cisco-mds fence-agents-cisco-ucs fence-agents-compute \
-    fence-agents-eaton-snmp fence-agents-emerson fence-agents-eps fence-agents-heuristics-ping fence-agents-ibmblade fence-agents-ifmib fence-agents-ilo2 \
-    fence-agents-intelmodular fence-agents-ipdu fence-agents-ipmilan fence-agents-kdump fence-agents-mpath fence-agents-redfish fence-agents-rhevm fence-agents-sbd \
-    fence-agents-scsi fence-agents-vmware-rest fence-agents-vmware-soap \
+    && dnf --enablerepo=highavailability install -y fence-agents-amt-ws fence-agents-apc-snmp fence-agents-cisco-ucs \
+    fence-agents-eaton-snmp fence-agents-emerson fence-agents-eps fence-agents-ibmblade fence-agents-ifmib fence-agents-ilo2 \
+    fence-agents-intelmodular fence-agents-ipdu fence-agents-ipmilan fence-agents-redfish fence-agents-rhevm \
+    fence-agents-vmware-rest fence-agents-vmware-soap \
     fence-agents-aws fence-agents-azure-arm fence-agents-gce \
     && dnf clean all -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN dnf install -y dnf-plugins-core \
     fence-agents-eaton-snmp fence-agents-emerson fence-agents-eps fence-agents-ibmblade fence-agents-ifmib fence-agents-ilo2 \
     fence-agents-intelmodular fence-agents-ipdu fence-agents-ipmilan fence-agents-redfish fence-agents-rhevm \
     fence-agents-vmware-rest fence-agents-vmware-soap \
+    fence-agents-kubevirt fence-agents-ibm-powervs fence-agents-ibm-vpc \
     fence-agents-aws fence-agents-azure-arm fence-agents-gce \
     && dnf clean all -y
 


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
FAR is doing [power-based fencing](https://github.com/ClusterLabs/fence-agents/blob/main/doc/FenceAgentAPI.md#definitions) (node is power-cycled, reset, or turned off to prevent it from issuing I/Os), and 7 non-power-based agents are included in FAR dockerfile. Thus, we can remove them and add 3 new supported agents.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Exclude 7 non-power-based agents from installation (i.e., [`fence_cisco_mds`](https://www.mankier.com/8/fence_cisco_mds), [`fence_compute`](https://www.mankier.com/8/fence_compute), [`fence_heuristics_ping`](https://www.mankier.com/8/fence_heuristics_ping), [`fence_kdump`](https://www.mankier.com/8/fence_kdump), [`fence_mpath`](https://www.mankier.com/8/fence_mpath), [`fence_sbd`](https://www.mankier.com/8/fence_sbd), and [`fence_scsi`](https://www.mankier.com/8/fence_scsi)).
- Include 3 RHEL-supported agents (i.e., [`fence_kubevirt`](https://www.mankier.com/8/fence_kubevirt), [`fence_ibm_powervs`](https://www.mankier.com/8/fence_ibm_powervs), and [`fence_ibm_vpc`](https://www.mankier.com/8/fence_ibm_vpc)).

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

[ECOPROJECT-2081](https://issues.redhat.com//browse/ECOPROJECT-2081) & [ECOPROJECT-1998](https://issues.redhat.com//browse/ECOPROJECT-1998)
#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->

- Add webhook test for the supported agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the set of fence-agent packages installed in the Docker image, replacing some existing packages with new ones.
  * Revised installation comments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->