### PR TITLE
Adding template to shared parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,43 @@ spec:
 
 If a parameter is defined in both a Secret and in the `sharedparameters` or `nodeparameters` fields of the CR, a **validation error will occur** to prevent ambiguity.
 
-Here is an example for a Secret
+#### NodeName Template Support:
+
+Both `sharedparameters` and **shared Secret parameters** support Go template syntax for dynamic node name substitution:
+
+* Use `{{.NodeName}}` in parameter values to substitute the actual node name at runtime.
+* Templates are processed for both shared parameters and shared/node secret parameters.
+* Invalid template syntax will prevent fence agent execution and log appropriate error messages.
+
+**Examples:**
+
+For shared parameters:
+```yaml
+spec:
+  sharedparameters:
+    --systems-uri: "/redfish/v1/Systems/{{.NodeName}}"
+    --hostname: "{{.NodeName}}.example.com"
+```
+
+For shared secrets:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fence-agents-credentials-shared
+  namespace: openshift-workload-availability
+type: Opaque
+data:
+  --systems-uri: L3JlZGZpc2gvdjEvU3lzdGVtcy97ey5Ob2RlTmFtZX19  # "/redfish/v1/Systems/{{.NodeName}}" base64 encoded
+  --hostname: e3suTm9kZU5hbWV9fS5leGFtcGxlLmNvbQ==  # "{{.NodeName}}.example.com" base64 encoded
+  --password: eXl5eQ==  # "yyyy" base64 encoded
+```
+
+When a FenceAgentsRemediation is processed for node `worker-1`, the templates will be resolved to:
+- `--systems-uri=/redfish/v1/Systems/worker-1`
+- `--hostname=worker-1.example.com`
+
+Here is an example for a Secret without templates:
 ```yaml
 apiVersion: v1
 kind: Secret

--- a/api/v1alpha1/fenceagentsremediationtemplate_webhook.go
+++ b/api/v1alpha1/fenceagentsremediationtemplate_webhook.go
@@ -17,13 +17,18 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	commonAnnotations "github.com/medik8s/common/pkg/annotations"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/medik8s/fence-agents-remediation/pkg/template"
 )
 
 var (
@@ -59,20 +64,55 @@ func (farTemplate *FenceAgentsRemediationTemplate) Default() {
 
 var _ webhook.Validator = &FenceAgentsRemediationTemplate{}
 
+// validateTemplateParameters validates template syntax in shared parameters and collects all errors
+func validateTemplateParameters(spec *FenceAgentsRemediationSpec) error {
+	var validationErrors []error
+
+	// Validate template syntax in shared parameters
+	for paramName, paramValue := range spec.SharedParameters {
+		if _, err := template.ProcessParameterValue(paramValue, "dummy-node-name"); err != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("invalid template syntax in shared parameter %s: %w", paramName, err))
+		}
+	}
+
+	return errors.NewAggregate(validationErrors)
+}
+
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (farTemplate *FenceAgentsRemediationTemplate) ValidateCreate() (admission.Warnings, error) {
 	webhookFARTemplateLog.Info("validate create", "name", farTemplate.Name)
-	return validateFAR(&farTemplate.Spec.Template.Spec)
+
+	// Aggregate template validation and FAR validation errors
+	aggregated := errors.NewAggregate([]error{
+		validateTemplateParameters(&farTemplate.Spec.Template.Spec),
+		validateFARTemplateSpec(&farTemplate.Spec.Template.Spec),
+	})
+
+	return admission.Warnings{}, aggregated
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (farTemplate *FenceAgentsRemediationTemplate) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	webhookFARTemplateLog.Info("validate update", "name", farTemplate.Name)
-	return validateFAR(&farTemplate.Spec.Template.Spec)
+
+	// Aggregate template validation and FAR validation errors
+	aggregated := errors.NewAggregate([]error{
+		validateTemplateParameters(&farTemplate.Spec.Template.Spec),
+		validateFARTemplateSpec(&farTemplate.Spec.Template.Spec),
+	})
+
+	return admission.Warnings{}, aggregated
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (farTemplate *FenceAgentsRemediationTemplate) ValidateDelete() (admission.Warnings, error) {
 	webhookFARTemplateLog.Info("validate delete", "name", farTemplate.Name)
 	return nil, nil
+}
+
+// validateFARTemplateSpec validates the underlying FenceAgentsRemediationSpec
+func validateFARTemplateSpec(spec *FenceAgentsRemediationSpec) error {
+	warnings, err := validateFAR(spec)
+	_ = warnings // Ignore warnings for now
+	return err
 }

--- a/api/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
+++ b/api/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
@@ -18,6 +18,24 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 			})
 		})
 
+		When("template has only shared parameters and no node parameters", func() {
+			It("should be accepted", func() {
+				farTemplate := getTestFARTemplate(validAgentName)
+				farTemplate.Spec.Template.Spec.SharedParameters = map[ParameterName]string{
+					"ip":       "192.168.1.100",
+					"username": "admin",
+					"password": "secret",
+				}
+				// Explicitly ensure no node parameters
+				farTemplate.Spec.Template.Spec.NodeParameters = nil
+
+				warnings, err := farTemplate.ValidateCreate()
+				Expect(err).NotTo(HaveOccurred())
+				// No warnings expected about node-specific parameters since there are none
+				Expect(warnings).To(BeEmpty())
+			})
+		})
+
 		When("agent name was not found ", func() {
 			It("should be rejected", func() {
 				farTemplate := getTestFARTemplate(invalidAgentName)
@@ -131,7 +149,7 @@ var _ = Describe("FenceAgentsRemediationTemplate Validation", func() {
 							Agent: validAgentName,
 							SharedParameters: map[ParameterName]string{
 								"--systems-uri": "/redfish/v1/Systems/{{.NodeName", // Missing closing brace
-								"--hostname":    "{{.InvalidField}}",               // Invalid field
+								"--hostname":    "{{.InvalidField}}",               // Unsupported name, only NodeName is supported
 								"--port":        "{{.NodeName}}.com",               // Valid template
 								"--invalid":     "/path/{{.NodeName",               // Another missing closing brace
 							},

--- a/controllers/fenceagentsremediation_controller.go
+++ b/controllers/fenceagentsremediation_controller.go
@@ -375,7 +375,7 @@ func (r *FenceAgentsRemediationReconciler) collectRemediationSecretParams(ctx co
 func (r *FenceAgentsRemediationReconciler) processSecretParams(secretParams map[string]string, secretName, nodeName string) (map[string]string, error) {
 	processedSecretParams := map[string]string{}
 	for key, val := range secretParams {
-		processedParamVal, err := template.ProcessParameterValue(val, nodeName)
+		processedParamVal, err := template.RenderParameterTemplate(val, nodeName)
 		if err != nil {
 			r.Log.Error(err, "Failed to process parameter value stored in secret", "param key", key, "secret name", secretName)
 			return nil, err
@@ -441,7 +441,7 @@ func (r *FenceAgentsRemediationReconciler) buildFenceAgentParams(ctx context.Con
 	// append shared parameters
 	for paramName, paramVal := range far.Spec.SharedParameters {
 		// Process template in parameter value
-		processedParamVal, err := template.ProcessParameterValue(paramVal, nodeName)
+		processedParamVal, err := template.RenderParameterTemplate(paramVal, nodeName)
 		if err != nil {
 			r.Log.Error(err, "Failed to process template in shared parameter", "parameter", paramName, "value", paramVal, "node", nodeName)
 			return nil, false, err

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -27,9 +27,9 @@ type TemplateData struct {
 	NodeName string `json:"nodeName"`
 }
 
-// ProcessParameterValue processes a parameter value string with Go template syntax
+// RenderParameterTemplate processes a parameter value string with Go template syntax
 // It replaces placeholders like {{.NodeName}} with actual values
-func ProcessParameterValue(paramValue string, nodeName string) (string, error) {
+func RenderParameterTemplate(paramValue string, nodeName string) (string, error) {
 	if nodeName == "" {
 		return "", fmt.Errorf("nodeName cannot be empty")
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// TemplateData contains the data available for template substitution
+type TemplateData struct {
+	NodeName string `json:"nodeName"`
+}
+
+// ProcessParameterValue processes a parameter value string with Go template syntax
+// It replaces placeholders like {{.NodeName}} with actual values
+func ProcessParameterValue(paramValue string, nodeName string) (string, error) {
+	if nodeName == "" {
+		return "", fmt.Errorf("nodeName cannot be empty")
+	}
+
+	// Create template data
+	data := TemplateData{
+		NodeName: nodeName,
+	}
+
+	// Process the parameter value with Go templates
+	return processTemplateString(paramValue, data)
+}
+
+// processTemplateString processes a string with Go template syntax
+func processTemplateString(templateStr string, data TemplateData) (string, error) {
+	tmpl, err := template.New("far-template").Parse(templateStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -29,12 +29,12 @@ func TestTemplate(t *testing.T) {
 }
 
 var _ = Describe("Template Processing", func() {
-	Describe("ProcessParameterValue", func() {
+	Describe("RenderParameterTemplate", func() {
 		It("should replace NodeName placeholder", func() {
 			paramValue := "/redfish/v1/Systems/{{.NodeName}}"
 			nodeName := "worker-1"
 
-			result, err := ProcessParameterValue(paramValue, nodeName)
+			result, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal("/redfish/v1/Systems/worker-1"))
 		})
@@ -43,7 +43,7 @@ var _ = Describe("Template Processing", func() {
 			paramValue := "https://{{.NodeName}}.example.com/{{.NodeName}}/power"
 			nodeName := "worker-1"
 
-			result, err := ProcessParameterValue(paramValue, nodeName)
+			result, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal("https://worker-1.example.com/worker-1/power"))
 		})
@@ -52,7 +52,7 @@ var _ = Describe("Template Processing", func() {
 			paramValue := "/redfish/v1/Systems/{{.WrongTemplate}}"
 			nodeName := "worker-1"
 
-			_, err := ProcessParameterValue(paramValue, nodeName)
+			_, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("can't evaluate field WrongTemplate"))
 		})
@@ -61,7 +61,7 @@ var _ = Describe("Template Processing", func() {
 			paramValue := "/redfish/v1/Systems/{{.NodeName}}"
 			nodeName := ""
 
-			_, err := ProcessParameterValue(paramValue, nodeName)
+			_, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("nodeName cannot be empty"))
 		})
@@ -70,7 +70,7 @@ var _ = Describe("Template Processing", func() {
 			paramValue := "/redfish/v1/Systems/{{.NodeName"
 			nodeName := "worker-1"
 
-			_, err := ProcessParameterValue(paramValue, nodeName)
+			_, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
 		})
@@ -79,7 +79,7 @@ var _ = Describe("Template Processing", func() {
 			paramValue := "/redfish/v1/Systems/static-value"
 			nodeName := "worker-1"
 
-			result, err := ProcessParameterValue(paramValue, nodeName)
+			result, err := RenderParameterTemplate(paramValue, nodeName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal("/redfish/v1/Systems/static-value"))
 		})

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Template Utils Suite")
+}
+
+var _ = Describe("Template Processing", func() {
+	Describe("ProcessParameterValue", func() {
+		It("should replace NodeName placeholder", func() {
+			paramValue := "/redfish/v1/Systems/{{.NodeName}}"
+			nodeName := "worker-1"
+
+			result, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("/redfish/v1/Systems/worker-1"))
+		})
+
+		It("should handle multiple placeholders", func() {
+			paramValue := "https://{{.NodeName}}.example.com/{{.NodeName}}/power"
+			nodeName := "worker-1"
+
+			result, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("https://worker-1.example.com/worker-1/power"))
+		})
+
+		It("should return error for non existing template", func() {
+			paramValue := "/redfish/v1/Systems/{{.WrongTemplate}}"
+			nodeName := "worker-1"
+
+			_, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("can't evaluate field WrongTemplate"))
+		})
+
+		It("should return error for empty node name", func() {
+			paramValue := "/redfish/v1/Systems/{{.NodeName}}"
+			nodeName := ""
+
+			_, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("nodeName cannot be empty"))
+		})
+
+		It("should return error for invalid template syntax", func() {
+			paramValue := "/redfish/v1/Systems/{{.NodeName"
+			nodeName := "worker-1"
+
+			_, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse template"))
+		})
+
+		It("should handle strings without templates", func() {
+			paramValue := "/redfish/v1/Systems/static-value"
+			nodeName := "worker-1"
+
+			result, err := ProcessParameterValue(paramValue, nodeName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("/redfish/v1/Systems/static-value"))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
In order to avoid hard coding node details, for some fence agents a template mechanism could eliminate the need to hard code node specifics, i.e.

#### Changes made
- Adding the option to use the template "NodeName" in shared parameters
- In case this template exist switch it with actual node name during runtime
- Add a webhook validation to make sure the template is set properly in the Spec in order to avoid later runtime issues
- Adding Unit tests


#### Which issue(s) this PR fixes
[RHWA-97](https://issues.redhat.com//browse/RHWA-97)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Go template syntax in shared parameters and shared Secret parameters, allowing dynamic substitution of node names using `{{.NodeName}}`.
  * Documentation updated with usage instructions and examples for template support.

* **Bug Fixes**
  * Improved error handling to prevent fence agent execution if template syntax is invalid, with errors logged and command execution skipped.

* **Tests**
  * Expanded unit and integration test coverage for template processing, including correct substitution and error scenarios in both parameters and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->