### PR TITLE
Add podAntiAffinity to controller-manager to improve HA

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,3 +69,17 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: control-plane
+                    operator: In
+                    values:
+                      - controller-manager
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - fence-agents-remediation-operator
+              topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
#### Why we need this PR
In the current deployment configuration, multiple replicas of the controller-manager can be scheduled on the same node. This creates a single point of failure. This setup does not fully utilize the benefits of having multiple replicas. With better placement, we can use the replicas more effectively.

#### Changes made

- Added `podAntiAffinity` rules to controller-manager in "config/manager/manager.yaml"
- Ensures that pods with the same labels (`control-plane=controller-manager`, `app.kubernetes.io/name=fence-agents-remediation-operator`) are not scheduled on the same node
- Uses `requiredDuringSchedulingIgnoredDuringExecution` with `topologyKey: kubernetes.io/hostname`


#### Which issue(s) this PR fixes

#### Test plan
