### PR TITLE
Add optional checkout_ref input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ on:
      ocp_version:
        description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
        required: false
+     checkout_ref:
+       description: 'Override the ref to checkout (defaults to the triggering ref)'
+       required: false
+       default: ''
 
 permissions:
   contents: write
@@ -44,6 +48,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.checkout_ref || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

Add an optional `checkout_ref` input to the Release workflow's `workflow_dispatch` trigger. This allows overriding the Git ref checked out during a manual release run. When left empty (the default), it falls back to `github.ref`, preserving existing behavior.

### Changes
- Added `checkout_ref` input to `workflow_dispatch.inputs` in `release.yml`
- Added `ref: ${{ inputs.checkout_ref || github.ref }}` to the `actions/checkout` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)