### PR TITLE
Add telco best practices certsuite compliance

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -410,11 +410,20 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 image: quay.io/medik8s/fence-agents-remediation-operator:latest
+                lifecycle:
+                  postStart:
+                    exec:
+                      command:
+                      - /bin/true
+                  preStop:
+                    exec:
+                      command:
+                      - sleep
+                      - "5"
                 livenessProbe:
                   httpGet:
                     path: /healthz
                     port: 8081
-                  initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
                 readinessProbe:
@@ -436,13 +445,20 @@ spec:
                     drop:
                     - ALL
                   readOnlyRootFilesystem: true
+                startupProbe:
+                  failureThreshold: 12
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  periodSeconds: 5
+                terminationMessagePolicy: FallbackToLogsOnError
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: fence-agents-remediation-controller-manager
-              terminationGracePeriodSeconds: 10
+              terminationGracePeriodSeconds: 15
               topologySpreadConstraints:
               - labelSelector:
                   matchLabels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,7 +56,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
@@ -64,6 +63,20 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          failureThreshold: 12
+          periodSeconds: 5
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/true"]
+          preStop:
+            exec:
+              command: ["sleep", "5"]
+        terminationMessagePolicy: FallbackToLogsOnError
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
@@ -74,7 +87,7 @@ spec:
             cpu: 10m
             memory: 64Mi
       serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 15
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
## Summary

Addresses certsuite test failures to qualify FAR for the "Meets Best Practices" label in RHEC (Red Hat Ecosystem Catalog).

Related: [RHWA-449](https://redhat.atlassian.net/browse/RHWA-449) / [RHWA-988](https://redhat.atlassian.net/browse/RHWA-988)

## Problem

Certsuite testing flagged missing lifecycle hooks, startup probe, and terminationMessagePolicy — preventing the operator from receiving the "Meets Best Practices" certification label required for telco customers and RHEC visibility.

## Changes

### Manager Container (`config/manager/manager.yaml`)

**Added:**
- `startupProbe`: httpGet on `/healthz:8081` with 12 attempts × 5s = 60s budget
  - Protects slow-starting containers from premature liveness probe termination
- `lifecycle.postStart`: no-op `/bin/true` (certsuite compliance requirement)
- `lifecycle.preStop`: `sleep 5` for endpoint propagation delay
  - Prevents traffic routing to terminating pods during endpoint update propagation
- `terminationMessagePolicy: FallbackToLogsOnError`
  - Captures last log output as termination message on crash

**Modified:**
- Removed `initialDelaySeconds: 15` from livenessProbe (superseded by startupProbe)
- Bumped `terminationGracePeriodSeconds` from 10 to 15 (accommodate 5s preStop + actual shutdown)

### Bundle

Regenerated bundle (`make bundle-reset`) with all changes.

## Certsuite Tests Addressed

✅ **Fixed in this PR:**
1. `lifecycle-container-poststart` — Added postStart hook
2. `lifecycle-container-prestop` — Added preStop hook
3. `lifecycle-startup-probe` — Added startup probe
4. `observability-termination-policy` — Set FallbackToLogsOnError

## Testing

- ✅ Bundle validation passes (`make bundle-validate`)
- ✅ CSV includes all new fields in manager container deployment

## Notes

- postStart hook is a no-op (`/bin/true`) for compliance only; container doesn't require initialization before serving
- Same pattern as NHC operator (PR medik8s/node-healthcheck-operator#406)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced controller pod health monitoring by adding startup and liveness probes for improved reliability and faster recovery from failures.
  * Improved graceful shutdown behavior with extended termination grace period, allowing adequate time for resource cleanup.
  * Added lifecycle hooks for better control over service startup and shutdown sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/medik8s/fence-agents-remediation/pull/203)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->