### PR TITLE
fix: remove finalizer when node is deleted and remediation is timed out by NHC

### DIFF
--- a/internal/controller/fenceagentsremediation_controller.go
+++ b/internal/controller/fenceagentsremediation_controller.go
@@ -119,43 +119,54 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		r.Log.Error(err, "Unexpected error when validating CR's name with nodes' names", "CR's Name", req.Name)
 		return emptyResult, err
 	}
-	if node == nil {
-		// Node not found — it may have been deleted by MDR (or another remediator).
-		// If NHC has already timed out and is also trying to delete this CR, the
-		// finalizer would block that deletion forever since there is no node to clean up.
-		// Remove the finalizer directly so the pending deletion can complete.
-		if isTimedOutByNHC(far) && far.DeletionTimestamp != nil {
-			r.Executor.Remove(far.GetUID())
-			r.Log.Info("Node not found; removing finalizer to unblock NHC deletion of timed-out remediation", "remediation name", far.GetName())
-			controllerutil.RemoveFinalizer(far, v1alpha1.FARFinalizer)
-			if err := r.Client.Update(ctx, far); err != nil {
-				return emptyResult, fmt.Errorf("failed to remove finalizer from CR - %w", err)
-			}
-			return emptyResult, nil
+
+	// Handle deletion first - this is the standard reconcile pattern
+	// Check if CR is being deleted (has DeletionTimestamp)
+	if !far.ObjectMeta.DeletionTimestamp.IsZero() {
+		r.Log.Info("CR deletion timestamp is set", "CR Name", req.Name)
+
+		// Log remediation state if it didn't complete successfully
+		if !meta.IsStatusConditionPresentAndEqual(far.Status.Conditions, commonConditions.SucceededType, metav1.ConditionTrue) {
+			processingCondition := meta.FindStatusCondition(far.Status.Conditions, commonConditions.ProcessingType).Status
+			fenceAgentActionSucceededCondition := meta.FindStatusCondition(far.Status.Conditions, utils.FenceAgentActionSucceededType).Status
+			succeededCondition := meta.FindStatusCondition(far.Status.Conditions, commonConditions.SucceededType).Status
+			r.Log.Info("FAR didn't finish remediate the node", "CR Name", req.Name, "processing condition", processingCondition,
+				"fenceAgentActionSucceeded condition", fenceAgentActionSucceededCondition, "succeeded condition", succeededCondition)
 		}
-		r.Log.Error(err, "Could not find CR's target node", "CR's Name", req.Name, "Expected node name", v1alpha1.GetNodeName(far))
-		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
-		commonEvents.WarningEvent(r.Recorder, far, utils.EventReasonCrNodeNotFound, utils.EventMessageCrNodeNotFound)
-		return emptyResult, err
+
+		// Always stop the executor on deletion - it's a no-op if already stopped
+		// This ensures cleanup even if conditions are corrupted/missing
+		r.Executor.Remove(far.GetUID())
+
+		// handleFARDeletion is nil-safe: if node is missing (e.g., deleted by MDR or another remediator),
+		// it skips taint removal and proceeds directly to finalizer removal
+		return r.handleFARDeletion(ctx, far, node)
 	}
 
 	// Check NHC timeout annotation
+	// When NHC times out a remediation, it annotates and then deletes the CR
 	if isTimedOutByNHC(far) {
-		r.Executor.Remove(far.GetUID())
-		if far.DeletionTimestamp != nil {
-			// Removing finalizer so NHC deletion of the remediation can be completed
-			r.Log.Info("Cleaning up a timed-out remediation which is deleted by NHC", "remediation name", far.GetName())
-			// Node found, cleanup Taints before removing the finalizer
-			return r.handleFARDeletion(ctx, far, node)
-		}
 		r.Log.Info(utils.EventMessageRemediationStoppedByNHC)
+		r.Executor.Remove(far.GetUID())
 		utils.UpdateConditions(utils.RemediationInterruptedByNHC, far, r.Log)
 		commonEvents.RemediationStoppedByNHC(r.Recorder, far)
-		return emptyResult, err
+		return emptyResult, nil
+	}
+
+	// Check if node exists
+	// The FAR CR must be removable even when the node no longer exists (handled in deletion path above)
+	// Here we only deal with non-deleting CRs that reference a missing node
+	// If the node was deleted (e.g., by MDR or manually), the remediation is no longer relevant
+	if node == nil {
+		r.Log.Info("couldn't find node matching remediation, remediation skipped", "CR Name", req.Name, "Expected node name", v1alpha1.GetNodeName(far))
+		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
+		commonEvents.WarningEvent(r.Recorder, far, utils.EventReasonCrNodeNotFound, utils.EventMessageCrNodeNotFound)
+		// Return without error and without requeue - the node is gone, no point in retrying
+		return emptyResult, nil
 	}
 
 	// Add finalizer when the CR is created
-	if !controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) && far.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) {
 		controllerutil.AddFinalizer(far, v1alpha1.FARFinalizer)
 		if err := r.Client.Update(context.Background(), far); err != nil {
 			return emptyResult, fmt.Errorf("failed to add finalizer to the CR - %w", err)
@@ -166,21 +177,8 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		utils.UpdateConditions(utils.RemediationStarted, far, r.Log)
 		commonEvents.NormalEvent(r.Recorder, far, utils.EventReasonAddFinalizer, utils.EventMessageAddFinalizer)
 		return requeueImmediately, nil
-	} else if controllerutil.ContainsFinalizer(far, v1alpha1.FARFinalizer) && !far.ObjectMeta.DeletionTimestamp.IsZero() {
-		// Delete CR only when a finalizer and DeletionTimestamp are set
-		r.Log.Info("CR's deletion timestamp is not zero, and FAR finalizer exists", "CR Name", req.Name)
-
-		if !meta.IsStatusConditionPresentAndEqual(far.Status.Conditions, commonConditions.SucceededType, metav1.ConditionTrue) {
-			processingCondition := meta.FindStatusCondition(far.Status.Conditions, commonConditions.ProcessingType).Status
-			fenceAgentActionSucceededCondition := meta.FindStatusCondition(far.Status.Conditions, utils.FenceAgentActionSucceededType).Status
-			succeededCondition := meta.FindStatusCondition(far.Status.Conditions, commonConditions.SucceededType).Status
-			r.Log.Info("FAR didn't finish remediate the node ", "CR Name", req.Name, "processing condition", processingCondition,
-				"fenceAgentActionSucceeded condition", fenceAgentActionSucceededCondition, "succeeded condition", succeededCondition)
-			r.Executor.Remove(far.GetUID())
-		}
-
-		return r.handleFARDeletion(ctx, far, node)
 	}
+
 	// Add FAR (medik8s) remediation taint
 	taintAdded, err := utils.AppendTaint(r.Client, node.Name, utils.CreateRemediationTaint())
 	if err != nil {
@@ -266,38 +264,43 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 func (r *FenceAgentsRemediationReconciler) handleFARDeletion(ctx context.Context, far *v1alpha1.FenceAgentsRemediation, node *corev1.Node) (ctrl.Result, error) {
 	emptyResult := ctrl.Result{}
 
-	// remove out-of-service taint when using OutOfServiceTaint remediation
-	if far.Spec.RemediationStrategy == v1alpha1.OutOfServiceTaintRemediationStrategy {
-		r.Log.Info("Removing out-of-service taint", "Fence Agent", far.Spec.Agent, "Node Name", node.Name)
-		taint := utils.CreateOutOfServiceTaint()
+	// Only attempt taint removal if node still exists (it may have been deleted by MDR or another remediator)
+	if node != nil {
+		// remove out-of-service taint when using OutOfServiceTaint remediation
+		if far.Spec.RemediationStrategy == v1alpha1.OutOfServiceTaintRemediationStrategy {
+			r.Log.Info("Removing out-of-service taint", "Fence Agent", far.Spec.Agent, "Node Name", node.Name)
+			taint := utils.CreateOutOfServiceTaint()
+			if err := utils.RemoveTaint(r.Client, node.Name, taint); err != nil {
+				if apiErrors.IsConflict(err) {
+					r.Log.Error(err, "Failed to remove taint from node due to node update, retrying... ,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+					return ctrl.Result{RequeueAfter: time.Second}, nil
+				} else if !apiErrors.IsNotFound(err) {
+					r.Log.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+					return emptyResult, err
+				}
+			}
+			r.Log.Info("out-of-service taint was removed", "Node Name", node.Name)
+			commonEvents.NormalEvent(r.Recorder, node, utils.EventReasonRemoveOutOfServiceTaint, utils.EventMessageRemoveOutOfServiceTaint)
+		}
+
+		// remove node's taints
+		taint := utils.CreateRemediationTaint()
 		if err := utils.RemoveTaint(r.Client, node.Name, taint); err != nil {
 			if apiErrors.IsConflict(err) {
-				r.Log.Error(err, "Failed to remove taint from node due to node update, retrying... ,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
+				r.Log.Info("Failed to remove taint from node due to node update, retrying... ,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
 				return ctrl.Result{RequeueAfter: time.Second}, nil
+
 			} else if !apiErrors.IsNotFound(err) {
 				r.Log.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
 				return emptyResult, err
 			}
 		}
-		r.Log.Info("out-of-service taint was removed", "Node Name", node.Name)
-		commonEvents.NormalEvent(r.Recorder, node, utils.EventReasonRemoveOutOfServiceTaint, utils.EventMessageRemoveOutOfServiceTaint)
+
+		r.Log.Info("FAR remediation taint was removed", "Node Name", node.Name)
+		commonEvents.NormalEvent(r.Recorder, node, utils.EventReasonRemoveRemediationTaint, utils.EventMessageRemoveRemediationTaint)
+	} else {
+		r.Log.Info("Node already deleted, skipping taint removal", "CR Name", far.Name)
 	}
-
-	// remove node's taints
-	taint := utils.CreateRemediationTaint()
-	if err := utils.RemoveTaint(r.Client, node.Name, taint); err != nil {
-		if apiErrors.IsConflict(err) {
-			r.Log.Info("Failed to remove taint from node due to node update, retrying... ,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
-			return ctrl.Result{RequeueAfter: time.Second}, nil
-
-		} else if !apiErrors.IsNotFound(err) {
-			r.Log.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", taint.Key, "taint effect", taint.Effect)
-			return emptyResult, err
-		}
-	}
-
-	r.Log.Info("FAR remediation taint was removed", "Node Name", node.Name)
-	commonEvents.NormalEvent(r.Recorder, node, utils.EventReasonRemoveRemediationTaint, utils.EventMessageRemoveRemediationTaint)
 
 	// remove finalizer
 	controllerutil.RemoveFinalizer(far, v1alpha1.FARFinalizer)

--- a/internal/controller/fenceagentsremediation_controller.go
+++ b/internal/controller/fenceagentsremediation_controller.go
@@ -120,6 +120,19 @@ func (r *FenceAgentsRemediationReconciler) Reconcile(ctx context.Context, req ct
 		return emptyResult, err
 	}
 	if node == nil {
+		// Node not found — it may have been deleted by MDR (or another remediator).
+		// If NHC has already timed out and is also trying to delete this CR, the
+		// finalizer would block that deletion forever since there is no node to clean up.
+		// Remove the finalizer directly so the pending deletion can complete.
+		if isTimedOutByNHC(far) && far.DeletionTimestamp != nil {
+			r.Executor.Remove(far.GetUID())
+			r.Log.Info("Node not found; removing finalizer to unblock NHC deletion of timed-out remediation", "remediation name", far.GetName())
+			controllerutil.RemoveFinalizer(far, v1alpha1.FARFinalizer)
+			if err := r.Client.Update(ctx, far); err != nil {
+				return emptyResult, fmt.Errorf("failed to remove finalizer from CR - %w", err)
+			}
+			return emptyResult, nil
+		}
 		r.Log.Error(err, "Could not find CR's target node", "CR's Name", req.Name, "Expected node name", v1alpha1.GetNodeName(far))
 		utils.UpdateConditions(utils.RemediationFinishedNodeNotFound, far, r.Log)
 		commonEvents.WarningEvent(r.Recorder, far, utils.EventReasonCrNodeNotFound, utils.EventMessageCrNodeNotFound)

--- a/internal/controller/fenceagentsremediation_controller_test.go
+++ b/internal/controller/fenceagentsremediation_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	commonAnnotations "github.com/medik8s/common/pkg/annotations"
 	commonConditions "github.com/medik8s/common/pkg/conditions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,7 +141,11 @@ var _ = Describe("FAR Controller", func() {
 		JustBeforeEach(func() {
 			// Create node, and FAR CR, and at the end clean them up with DeferCleanup
 			Expect(k8sClient.Create(context.Background(), node)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, context.Background(), node)
+			DeferCleanup(func() {
+				if err := k8sClient.Delete(context.Background(), node); err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			})
 
 			Expect(k8sClient.Create(context.Background(), nodeSecret)).To(Succeed())
 			DeferCleanup(k8sClient.Delete, context.Background(), nodeSecret)
@@ -508,6 +513,38 @@ var _ = Describe("FAR Controller", func() {
 				verifyNoEvent(corev1.EventTypeNormal, utils.EventReasonNodeRemediationCompleted, utils.EventReasonNodeRemediationCompleted)
 			})
 		})
+		When("FAR CR is NHC-timed-out and the node is deleted (e.g. by MDR)", func() {
+			BeforeEach(func() {
+				node = utils.GetNode("", workerNode)
+				underTestFAR = getFenceAgentsRemediation(workerNode, fenceAgentIPMI, testShareParam, testNodeParam, v1alpha1.ResourceDeletionRemediationStrategy)
+			})
+
+			It("should remove the finalizer and allow the CR deletion to complete", func() {
+				By("Waiting for the finalizer to be added (remediation has started)")
+				underTestFAR = verifyPreRemediationSucceed(underTestFAR, defaultNamespace, &farRemediationTaint)
+
+				By("Simulating NHC timeout: adding the NHC timed-out annotation")
+				Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTestFAR), underTestFAR)).To(Succeed())
+				if underTestFAR.Annotations == nil {
+					underTestFAR.Annotations = map[string]string{}
+				}
+				underTestFAR.Annotations[commonAnnotations.NhcTimedOut] = time.Now().Format(time.RFC3339)
+				Expect(k8sClient.Update(context.Background(), underTestFAR)).To(Succeed())
+
+				By("Simulating MDR deleting the node")
+				Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
+
+				By("Simulating NHC deleting the FAR CR")
+				Expect(k8sClient.Delete(context.Background(), underTestFAR)).To(Succeed())
+
+				By("Expecting the finalizer to be removed and the CR deletion to complete")
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTestFAR), &v1alpha1.FenceAgentsRemediation{})
+					return apierrors.IsNotFound(err)
+				}, timeoutPreRemediation, pollInterval).Should(BeTrue(), "FAR CR should have been deleted — finalizer must have been removed")
+			})
+		})
+
 		When("create FAR CR with invalid Action parameter", func() {
 			BeforeEach(func() {
 				node = utils.GetNode("", workerNode)

--- a/internal/controller/fenceagentsremediation_controller_test.go
+++ b/internal/controller/fenceagentsremediation_controller_test.go
@@ -545,6 +545,30 @@ var _ = Describe("FAR Controller", func() {
 			})
 		})
 
+		When("FAR CR is deleted and the node is already gone (no NHC timeout)", func() {
+			BeforeEach(func() {
+				node = utils.GetNode("", workerNode)
+				underTestFAR = getFenceAgentsRemediation(workerNode, fenceAgentIPMI, testShareParam, testNodeParam, v1alpha1.ResourceDeletionRemediationStrategy)
+			})
+
+			It("should remove the finalizer and allow the CR deletion to complete", func() {
+				By("Waiting for the finalizer to be added (remediation has started)")
+				underTestFAR = verifyPreRemediationSucceed(underTestFAR, defaultNamespace, &farRemediationTaint)
+
+				By("Simulating node deletion (e.g., cloud provider removed it, manual deletion)")
+				Expect(k8sClient.Delete(context.Background(), node)).To(Succeed())
+
+				By("User/system deletes the FAR CR (no NHC timeout annotation)")
+				Expect(k8sClient.Delete(context.Background(), underTestFAR)).To(Succeed())
+
+				By("Expecting the finalizer to be removed and the CR deletion to complete")
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(underTestFAR), &v1alpha1.FenceAgentsRemediation{})
+					return apierrors.IsNotFound(err)
+				}, timeoutPreRemediation, pollInterval).Should(BeTrue(), "FAR CR should have been deleted even without NHC timeout — finalizer must have been removed")
+			})
+		})
+
 		When("create FAR CR with invalid Action parameter", func() {
 			BeforeEach(func() {
 				node = utils.GetNode("", workerNode)


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR

In an escalation remediation scenario (FAR → MDR), FAR may fail to remediate in time, causing NHC to time it out and trigger MDR. MDR remediates by deleting the machine, which removes the node. When NHC subsequently tries to delete the FAR CR, the finalizer blocks the deletion forever — the controller returns early on node == nil before it ever reaches the NHC-timeout + DeletionTimestamp check. The FAR CR is then permanently stuck, leaking a finalizer on a remediation that is already abandoned.

#### Changes made
- Controller: handle the case where the node is gone but NHC has timed out and is deleting the CR — remove the finalizer directly so the deletion can complete.
- Tests: add regression test for the scenario; harden node teardown to tolerate already-deleted nodes.


#### Which issue(s) this PR fixes
[RHWA-697](https://redhat.atlassian.net/browse/RHWA-697)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FenceAgentsRemediation deletion handling so reconciliation completes reliably when NHC timeout is set and the target node is missing. Finalizers are removed correctly, in-flight executor work is stopped during deletion, and taint-cleanup is skipped when the node is already gone.

* **Tests**
  * Added/extended reconciliation coverage for (1) NHC timeout with node deleted before FAR deletion and (2) node deleted before FAR CR deletion, verifying eventual full CR cleanup and finalizer removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->