### PR TITLE
fix: catalog multi-channel support and upgrade metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ testbin/*
 
 # vscode directory
 .vscode/*
+
+catalog/
+catalog.Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,19 @@ export IMAGE_TAG
 
 CHANNELS ?= stable
 export CHANNELS
-DEFAULT_CHANNEL = stable
+DEFAULT_CHANNEL ?= stable
 export DEFAULT_CHANNEL
+
+# Validate DEFAULT_CHANNEL is in CHANNELS
+# When CHANNELS contains comma-separated values (e.g., "stable,beta"), we need to convert
+# commas to spaces for filter to match. We use a variable for the comma because Make treats
+# commas as function argument delimiters, causing $(subst ,, ,$(CHANNELS)) to misparse.
+comma := ,
+ifneq (,$(DEFAULT_CHANNEL))
+  ifeq (,$(filter $(DEFAULT_CHANNEL),$(subst $(comma), ,$(CHANNELS))))
+    $(error DEFAULT_CHANNEL "$(DEFAULT_CHANNEL)" must be present in CHANNELS "$(CHANNELS)")
+  endif
+endif
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ IMAGE_TAG = v$(VERSION)
 endif
 export IMAGE_TAG
 
-CHANNELS = stable
+CHANNELS ?= stable
 export CHANNELS
 DEFAULT_CHANNEL = stable
 export DEFAULT_CHANNEL
@@ -59,6 +59,7 @@ export DEFAULT_CHANNEL
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= $(DEFAULT_VERSION)
 PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
+SKIP_RANGE_LOWER ?=
 export VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
@@ -448,14 +449,29 @@ CATALOG_DIR := catalog
 CATALOG_DOCKERFILE := ${CATALOG_DIR}.Dockerfile
 CATALOG_INDEX := $(CATALOG_DIR)/index.yaml
 
+# Add olm.channel entries for each channel in CHANNELS.
+# For development version (0.0.1), omit replaces and skipRange to avoid OLM catalog validation errors.
 .PHONY: add_channel_entry_for_the_bundle
 add_channel_entry_for_the_bundle:
-	@echo "---" >> ${CATALOG_INDEX}
-	@echo "schema: olm.channel" >> ${CATALOG_INDEX}
-	@echo "package: ${OPERATOR_NAME}" >> ${CATALOG_INDEX}
-	@echo "name: ${CHANNELS}" >> ${CATALOG_INDEX}
-	@echo "entries:" >> ${CATALOG_INDEX}
-	@echo "  - name: ${OPERATOR_NAME}.v${VERSION}" >> ${CATALOG_INDEX}
+	@for channel in $(shell echo ${CHANNELS} | tr ',' ' '); do \
+		echo "---" >> ${CATALOG_INDEX}; \
+		echo "schema: olm.channel" >> ${CATALOG_INDEX}; \
+		echo "package: ${OPERATOR_NAME}" >> ${CATALOG_INDEX}; \
+		echo "name: $$channel" >> ${CATALOG_INDEX}; \
+		echo "entries:" >> ${CATALOG_INDEX}; \
+		echo "  - name: ${OPERATOR_NAME}.v${VERSION}" >> ${CATALOG_INDEX}; \
+		\
+		if [ -n "${PREVIOUS_VERSION}" ] && [ "${VERSION}" != "${DEFAULT_VERSION}" ] && [ "${PREVIOUS_VERSION}" != "${DEFAULT_VERSION}" ]; then \
+			echo "    replaces: ${OPERATOR_NAME}.v${PREVIOUS_VERSION}" >> ${CATALOG_INDEX}; \
+		fi; \
+		if [ -n "${SKIP_RANGE_LOWER}" ] && [ "${VERSION}" != "${DEFAULT_VERSION}" ] && [ "${VERSION}" != "${SKIP_RANGE_LOWER}" ]; then \
+			if ! printf '%s\n' "${SKIP_RANGE_LOWER}" "${VERSION}" | sort -V -C 2>/dev/null; then \
+				echo "Error: VERSION (${VERSION}) must be greater than SKIP_RANGE_LOWER (${SKIP_RANGE_LOWER})"; \
+				exit 1; \
+			fi; \
+			echo "    skipRange: '>=${SKIP_RANGE_LOWER} <${VERSION}'" >> ${CATALOG_INDEX}; \
+		fi; \
+	done
 
 .PHONY: catalog-build
 catalog-build: opm ## Build a file-based catalog image.
@@ -464,7 +480,7 @@ catalog-build: opm ## Build a file-based catalog image.
 	@mkdir -p ${CATALOG_DIR}
 	$(OPM) generate dockerfile ${CATALOG_DIR}
 	$(OPM) init ${OPERATOR_NAME} \
-		--default-channel=${CHANNELS} \
+		--default-channel=${DEFAULT_CHANNEL} \
 		--description=./README.md \
 		--icon=${BLUE_ICON_PATH} \
 		--output yaml \


### PR DESCRIPTION
#### Why we need this PR
The currently File-based catalog does not handle `multi-channel` correctly.

#### Changes made
* Use DEFAULT_CHANNEL in opm init
* Add channel iteration for multi-channel support
* Include upgrade metadata (replaces, skipRange) in channel entries.


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
```sh
make catalog-build
# expected: DEFAULT_CHANNEL: stable, one olm.channel entry with name: stable and no skipRange, nor replaces

CHANNELS=stable,test VERSION=0.4.0 PREVIOUS_VERSION=0.3.1 SKIP_RANGE_LOWER=0.2.0 make catalog-build
# expected: DEFAULT_CHANNEL: stable, two olm.channel blobs, one with name: stable and one with name: test, skipRange with 0.2.0 and 0.4.0, and replaces 0.3.1

# ensure DEFAULT_CHANNEL is in CHANNELS
CHANNELS=test VERSION=0.4.0 PREVIOUS_VERSION=0.3.1 SKIP_RANGE_LOWER=0.2.0 make catalog-build
Makefile:58: *** DEFAULT_CHANNEL "stable" must be present in CHANNELS "test".  Stop.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog builds now support multiple channels and can set a separate default channel.
  * Added optional support for generating `skipRange` entries during catalog creation.

* **Bug Fixes**
  * Build validation now prevents invalid channel configurations when the default channel is missing from the channel list.
  * Catalog metadata generation now handles comma-separated channel values correctly.

* **Chores**
  * Updated ignored files so generated catalog artifacts are not tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->