### PR TITLE
Add NetworkPolicy RBAC permission

### DIFF
--- a/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/fence-agents-remediation.clusterserviceversion.yaml
@@ -331,6 +331,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - storage.k8s.io
           resources:
           - volumeattachments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -77,6 +77,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - storage.k8s.io
   resources:
   - volumeattachments

--- a/internal/controller/fenceagentsremediation_controller.go
+++ b/internal/controller/fenceagentsremediation_controller.go
@@ -72,6 +72,7 @@ func (r *FenceAgentsRemediationReconciler) SetupWithManager(mgr ctrl.Manager) er
 // +kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=fence-agents-remediation.medik8s.io,resources=fenceagentsremediations/finalizers,verbs=update
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Summary

Add `networking.k8s.io/networkpolicies` RBAC (create, delete, update) to allow managing NetworkPolicies for operand workloads.

## Changes

- Add kubebuilder RBAC marker to controller
- Regenerate `config/rbac/role.yaml`
- Regenerate bundle CSV

## Test plan

- [x] `make manifests` — RBAC generated correctly
- [x] `make bundle-reset` — bundle validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)