### PR TITLE
Avoid caching Secrets

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
@@ -150,6 +151,11 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
+		},
 		Metrics: server.Options{
 			BindAddress:    metricsAddr,
 			SecureServing:  true,


### PR DESCRIPTION
Fixes #217.

Configure the manager client to bypass the controller-runtime cache for `corev1.Secret` objects. Secret reads now go directly to the API server, preventing a cluster-scoped Secret informer from being started and keeping access aligned with the existing namespace-scoped Secret RBAC.

All other resource reads continue to use the manager cache.

## Testing

- `go test ./cmd/...`
- `make test`: all four Ginkgo suites passed; the final bundle reset step could not complete locally because the existing `sed -r -i` command is GNU-specific and incompatible with macOS BSD `sed`.