### PR TITLE
Update to v5.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ IMAGE_REGISTRY ?= quay.io/medik8s
 export IMAGE_REGISTRY
 
 # When no version is set, use latest as image tags
-DEFAULT_VERSION := 0.0.1
+DEFAULT_VERSION := 5.8.0
 ifeq ($(origin VERSION), undefined)
 IMAGE_TAG = latest
 else ifeq ($(VERSION), $(DEFAULT_VERSION))

--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: fence-agents-remediation
-repo: github.com/medik8s/fence-agents-remediation
+repo: github.com/medik8s/fence-agents-remediation/v5
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: medik8s.io
   group: fence-agents-remediation
   kind: FenceAgentsRemediation
-  path: github.com/medik8s/fence-agents-remediation/api/v1alpha1
+  path: github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true
@@ -30,7 +30,7 @@ resources:
   domain: medik8s.io
   group: fence-agents-remediation
   kind: FenceAgentsRemediationTemplate
-  path: github.com/medik8s/fence-agents-remediation/api/v1alpha1
+  path: github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1
   version: v1alpha1
   webhooks:
     defaulting: true

--- a/api/v1alpha1/fenceagentsremediation_params.go
+++ b/api/v1alpha1/fenceagentsremediation_params.go
@@ -33,8 +33,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/medik8s/fence-agents-remediation/pkg/template"
-	"github.com/medik8s/fence-agents-remediation/pkg/validation"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/template"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/validation"
 )
 
 const (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,14 +48,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 
-	fenceagentsremediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/internal/controller"
+	fenceagentsremediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/internal/controller"
 
 	//+kubebuilder:scaffold:imports
-	webhookv1alpha1 "github.com/medik8s/fence-agents-remediation/internal/webhook/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
-	"github.com/medik8s/fence-agents-remediation/pkg/validation"
-	"github.com/medik8s/fence-agents-remediation/version"
+	webhookv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/internal/webhook/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/validation"
+	"github.com/medik8s/fence-agents-remediation/v5/version"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/medik8s/fence-agents-remediation
+module github.com/medik8s/fence-agents-remediation/v5
 
 // min version, matches k8s 1.36.3
 go 1.26.0

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -8,9 +8,9 @@ BUILD_DATE=$(date --utc -Iseconds)
 
 mkdir -p bin
 
-LDFLAGS_VALUE="-X github.com/medik8s/fence-agents-remediation/version.Version=${VERSION} "
-LDFLAGS_VALUE+="-X github.com/medik8s/fence-agents-remediation/version.GitCommit=${COMMIT} "
-LDFLAGS_VALUE+="-X github.com/medik8s/fence-agents-remediation/version.BuildDate=${BUILD_DATE} "
+LDFLAGS_VALUE="-X github.com/medik8s/fence-agents-remediation/v5/version.Version=${VERSION} "
+LDFLAGS_VALUE+="-X github.com/medik8s/fence-agents-remediation/v5/version.GitCommit=${COMMIT} "
+LDFLAGS_VALUE+="-X github.com/medik8s/fence-agents-remediation/v5/version.BuildDate=${BUILD_DATE} "
 # allow override for debugging flags
 LDFLAGS_DEBUG="${LDFLAGS_DEBUG:-" -s -w"}"
 LDFLAGS_VALUE+="${LDFLAGS_DEBUG}"

--- a/internal/controller/controllers_suite_test.go
+++ b/internal/controller/controllers_suite_test.go
@@ -38,8 +38,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	//+kubebuilder:scaffold:imports ## https://github.com/kubernetes-sigs/kubebuilder/issues/1487 ?
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/internal/controller/fenceagentsremediation_controller.go
+++ b/internal/controller/fenceagentsremediation_controller.go
@@ -42,9 +42,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
-	"github.com/medik8s/fence-agents-remediation/pkg/utils"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/utils"
 )
 
 // FenceAgentsRemediationReconciler reconciles a FenceAgentsRemediation object

--- a/internal/controller/fenceagentsremediation_controller_test.go
+++ b/internal/controller/fenceagentsremediation_controller_test.go
@@ -33,9 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
-	"github.com/medik8s/fence-agents-remediation/pkg/utils"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/utils"
 )
 
 const (

--- a/internal/controller/fenceagentsremediationtemplate_controller.go
+++ b/internal/controller/fenceagentsremediationtemplate_controller.go
@@ -39,9 +39,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
-	"github.com/medik8s/fence-agents-remediation/pkg/utils"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/utils"
 )
 
 // FenceAgentsRemediationTemplateReconciler reconciles a FenceAgentsRemediationTemplate object

--- a/internal/controller/fenceagentsremediationtemplate_controller_test.go
+++ b/internal/controller/fenceagentsremediationtemplate_controller_test.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/cli"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/cli"
 )
 
 var _ = Describe("FART Controller", func() {

--- a/internal/webhook/v1alpha1/fenceagentsremediation_webhook.go
+++ b/internal/webhook/v1alpha1/fenceagentsremediation_webhook.go
@@ -24,7 +24,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 var (

--- a/internal/webhook/v1alpha1/fenceagentsremediation_webhook_test.go
+++ b/internal/webhook/v1alpha1/fenceagentsremediation_webhook_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 var _ = Describe("FenceAgentsRemediation Validation", func() {

--- a/internal/webhook/v1alpha1/fenceagentsremediationtemplate_webhook.go
+++ b/internal/webhook/v1alpha1/fenceagentsremediationtemplate_webhook.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 var (

--- a/internal/webhook/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
+++ b/internal/webhook/v1alpha1/fenceagentsremediationtemplate_webhook_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 const testNs = "test-namespace"

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -41,8 +41,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/validation"
+	remediationv1alpha1 "github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/validation"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/cli/cliexecuter.go
+++ b/pkg/cli/cliexecuter.go
@@ -20,8 +20,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/utils"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/utils"
 )
 
 const (

--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 const (

--- a/pkg/utils/suite_test.go
+++ b/pkg/utils/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/pkg/utils/taints.go
+++ b/pkg/utils/taints.go
@@ -9,7 +9,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 var (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -24,7 +24,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/test/e2e/far_e2e_test.go
+++ b/test/e2e/far_e2e_test.go
@@ -25,9 +25,9 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
-	"github.com/medik8s/fence-agents-remediation/pkg/utils"
-	e2eUtils "github.com/medik8s/fence-agents-remediation/test/e2e/utils"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/pkg/utils"
+	e2eUtils "github.com/medik8s/fence-agents-remediation/v5/test/e2e/utils"
 )
 
 const (

--- a/test/e2e/utils/cluster.go
+++ b/test/e2e/utils/cluster.go
@@ -16,7 +16,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 // Inspired from https://github.com/hybrid-cloud-patterns/patterns-operator/blob/main/controllers/pattern_controller.go#L293-L313

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	"github.com/medik8s/fence-agents-remediation/api/v1alpha1"
+	"github.com/medik8s/fence-agents-remediation/v5/api/v1alpha1"
 )
 
 const (

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	// Version is the operator version
-	Version = "0.0.1"
+	Version = "5.8.0"
 	// GitCommit is the current git commit hash
 	GitCommit = "n/a"
 	// BuildDate is the build date


### PR DESCRIPTION
Updates NHC from v0.12 to v5.8 by updating go module path with `v5`. More info [here.](https://go.dev/ref/mod#major-version-suffixes)

Fixes https://redhat.atlassian.net/browse/RHWA-1395 